### PR TITLE
[과팅] 속한 팀 조회 기능

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -8,6 +8,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 
 @RequiredArgsConstructor
 @RestController
@@ -19,6 +23,11 @@ public class GroupController {
     @GetMapping
     public Page<GroupResponse> list(Pageable pageable) {
         return groupService.list(pageable).map(GroupResponse::from);
+    }
+
+    @GetMapping("/my")
+    public List<GroupResponse> mylist() {
+        return groupService.myList(1L).stream().map(GroupResponse::from).collect(Collectors.toUnmodifiableList());
     }
 
     @PostMapping

--- a/src/main/java/com/ting/ting/domain/Group.java
+++ b/src/main/java/com/ting/ting/domain/Group.java
@@ -57,6 +57,14 @@ public class Group {
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, fetch = FetchType.LAZY)
     private Set<User> joinRequests = new LinkedHashSet<>();
 
+    @JoinTable(
+            name = "group_member",
+            joinColumns = @JoinColumn(name = "group_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    @ManyToMany(fetch = FetchType.LAZY)
+    private Set<User> members = new LinkedHashSet<>();
+
     protected Group() {}
 
     private Group(User leader, String groupName, Gender gender, String school, int numOfMember, String memo) {
@@ -75,5 +83,15 @@ public class Group {
     public void addJoinRequests(User user) { this.joinRequests.add(user); }
 
     public void removeJoinRequests(User user) { this.joinRequests.remove(user); }
+
+    public void addMember(User user) {
+        this.members.add(user);
+        user.getGroups().add(this);
+    }
+
+    public void removeMember(User user) {
+        this.members.remove(user);
+        user.getGroups().remove(this);
+    }
 }
 

--- a/src/main/java/com/ting/ting/domain/Group.java
+++ b/src/main/java/com/ting/ting/domain/Group.java
@@ -5,7 +5,10 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.*;
-import javax.validation.constraints.*;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -22,7 +25,7 @@ public class Group {
     private Long id;
 
     @NotNull
-    @OneToOne(optional = false)
+    @OneToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_id")
     private User leader;
 

--- a/src/main/java/com/ting/ting/domain/User.java
+++ b/src/main/java/com/ting/ting/domain/User.java
@@ -10,6 +10,8 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Setter
 @Getter
@@ -57,6 +59,9 @@ public class User {
 
     @Column(name="ideal_photo")
     private String idealPhoto;
+
+    @ManyToMany(mappedBy = "members")
+    private Set<Group> groups = new LinkedHashSet<>();
 
     protected User() {}
 

--- a/src/main/java/com/ting/ting/dto/GroupDto.java
+++ b/src/main/java/com/ting/ting/dto/GroupDto.java
@@ -13,7 +13,6 @@ import lombok.Setter;
 public class GroupDto {
 
     Long id;
-    UserDto leaderDto;
     String groupName;
     Gender gender;
     int numOfMember;
@@ -22,7 +21,7 @@ public class GroupDto {
     String memo;
 
     public static GroupDto of(String groupName, Gender gender, int limit, String school, String memo) {
-        return new GroupDto(null, null, groupName, gender, limit, school, false, memo);
+        return new GroupDto(null, groupName, gender, limit, school, false, memo);
     }
 
     public Group toEntity(User leader) {
@@ -32,7 +31,6 @@ public class GroupDto {
     public static GroupDto from(Group entity) {
         return new GroupDto(
                 entity.getId(),
-                UserDto.from(entity.getLeader()),
                 entity.getGroupName(),
                 entity.getGender(),
                 entity.getNumOfMember(),

--- a/src/main/java/com/ting/ting/dto/response/GroupResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupResponse.java
@@ -5,15 +5,12 @@ import com.ting.ting.dto.GroupDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.io.Serializable;
-
 @AllArgsConstructor
 @Getter
 public class GroupResponse {
 
     Long id;
     String groupName;
-    String leaderName;
     Gender gender;
     int numOfMember;
     String school;
@@ -24,7 +21,6 @@ public class GroupResponse {
         return new GroupResponse(
                 dto.getId(),
                 dto.getGroupName(),
-                dto.getLeaderDto().getUsername(),
                 dto.getGender(),
                 dto.getNumOfMember(),
                 dto.getSchool(),

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -11,6 +11,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 
 @RequiredArgsConstructor
 @Transactional
@@ -22,6 +26,12 @@ public class GroupService {
 
     public Page<GroupDto> list(Pageable pageable) {
         return groupRepository.findAll(pageable).map(GroupDto::from);
+    }
+
+    public Set<GroupDto> myList(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+
+        return user.getGroups().stream().map(GroupDto::from).collect(Collectors.toSet());
     }
 
     public void saveGroup(GroupDto dto) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -27,3 +27,8 @@ insert into `group` (id, leader_id, group_name, gender, school, num_of_member, i
 insert into `group` (id, leader_id, group_name, gender, school, num_of_member, is_matched, memo) values (6, 6, '과팅팀6', 'W', '건국대학교', 3, false, '');
 insert into `group` (id, leader_id, group_name, gender, school, num_of_member, is_matched, memo) values (7, 7, '과팅팀7', 'W', '세종대학교', 2, false, '');
 insert into `group` (id, leader_id, group_name, gender, school, num_of_member, is_matched, memo) values (8, 8, '과팅팀8', 'W', '홍익대학교', 4, false, '');
+
+insert into group_member (group_id, user_id) values (2, 1);
+insert into group_member (group_id, user_id) values (3, 1);
+insert into group_member (group_id, user_id) values (4, 1);
+insert into group_member (group_id, user_id) values (5, 1);

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -18,6 +18,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -102,6 +104,26 @@ class GroupServiceTest {
                 .hasSize(1)
                 .extracting("id")
                 .containsExactly(request2.getId());
+    }
+
+    @DisplayName("과팅 - 내가 속한 팀 조회")
+    @Test
+    void givenUserId_whenSelectingListOfMyTeam_thenReturnsGroups() {
+        //Given
+        User user = createUser(1L);
+        Group group1 = createGroup(2L);
+        Group group2 = createGroup(3L);
+        group1.addMember(user);
+        group2.addMember(user);
+        Set<Long> expected = Set.of(group1.getId(), group2.getId());
+        given(userRepository.getReferenceById(user.getId())).willReturn(user);
+
+        // When
+        Set<Long> actual = groupService.myList(user.getId()).stream().map(GroupDto::getId).collect(Collectors.toSet());
+
+        // Then
+        assertThat(actual).hasSize(2);
+        assertThat(actual).isEqualTo(expected);
     }
 
     private Group createGroup() {


### PR DESCRIPTION
* `@JoinTable` 을 이용해서 과팅 팀 멤버 테이블을 정의하고 `User` 와 `Group` 을 매핑시켜줬습니다.
* `Group`의 조회 기능에서 팀장 정보는 필요하지 않다고 생각되어서 `GroupDto`, `GroupResponse` 에서 제외하고, leader (user) fetch 전략도 LAZY로 수정했습니다.
* `data.sql` 에 과팅 팀 멤버 더미 데이터를 추가했습니다. (`/groups/my` api 테스트를 했을 때 해당 더미 데이터를 확인할 수 있습니다.) 

This closes #9 