### PR TITLE
Swagger 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ting/ting/config/SwaggerConfig.java
+++ b/src/main/java/com/ting/ting/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.ting.ting.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public Docket restAPI() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.ting.ting"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Capstone Ting Project Spring Boot Rest API")
+                .version("1.0.0")
+                .description("캡스톤 프로젝트 소개팅 & 과팅 어플 관련 swagger api 입니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -33,6 +33,12 @@ public class BlindDateController {
         return "success";
     }
 
+    @PutMapping("/request/{blindRequestId}")
+    public String acceptRequest(@PathVariable long blindRequestId) {
+        blindRequestService.acceptRequest(blindRequestId);
+        return "success";
+    }
+
     @DeleteMapping("/request/{blindRequestId}")
     public String deleteRequest(@PathVariable long blindRequestId) {
         blindRequestService.deleteRequest(blindRequestId);

--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -33,9 +33,14 @@ public class BlindDateController {
         return "success";
     }
 
+    @DeleteMapping("/request/{blindRequestId}")
+    public String deleteRequest(@PathVariable long blindRequestId) {
+        blindRequestService.deleteRequest(blindRequestId);
+        return "success";
+    }
+
     @ExceptionHandler(UserException.class)
     public ResponseEntity<?> dbeHandler() {
         return ResponseEntity.badRequest().body("잘못된 정보를 입력하였습니다.");
     }
-
 }

--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -5,6 +5,7 @@ import com.ting.ting.dto.response.BlindUsersInfoResponse;
 import com.ting.ting.exception.UserException;
 import com.ting.ting.service.BlindRequestService;
 import com.ting.ting.service.UserService;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,9 +23,14 @@ public class BlindDateController {
         this.blindRequestService = blindRequestService;
     }
 
-    @GetMapping("users")
-    public List<BlindUsersInfoResponse> blindUsersInfo() {
-        return userService.usersInfo();
+    @GetMapping("users/m")
+    public List<BlindUsersInfoResponse> blindMenUsersInfo(Pageable pageable) {
+        return userService.menUsersInfo(pageable);
+    }
+
+    @GetMapping("users/w")
+    public List<BlindUsersInfoResponse> blindWomenUsersInfo(Pageable pageable) {
+        return userService.womenUsersInfo(pageable);
     }
 
     @PostMapping("/request")
@@ -34,17 +40,10 @@ public class BlindDateController {
     }
 
     @PutMapping("/request/{blindRequestId}")
-    public String acceptRequest(@PathVariable long blindRequestId) {
-        blindRequestService.acceptRequest(blindRequestId);
-        return "success";
-    }
-
-    @PutMapping("/request/{blindRequestId}")
     public String rejectRequest(@PathVariable long blindRequestId) {
         blindRequestService.rejectRequest(blindRequestId);
         return "success";
     }
-
 
     @DeleteMapping("/request/{blindRequestId}")
     public String deleteRequest(@PathVariable long blindRequestId) {

--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -2,8 +2,10 @@ package com.ting.ting.controller;
 
 import com.ting.ting.dto.request.SendBlindRequest;
 import com.ting.ting.dto.response.BlindUsersInfoResponse;
+import com.ting.ting.exception.UserException;
 import com.ting.ting.service.BlindRequestService;
 import com.ting.ting.service.UserService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,4 +32,10 @@ public class BlindDateController {
         blindRequestService.createJoinRequest(request.getFromUserId(), request.getToUserId());
         return "success";
     }
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<?> dbeHandler() {
+        return ResponseEntity.badRequest().body("잘못된 정보를 입력하였습니다.");
+    }
+
 }

--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -1,10 +1,10 @@
 package com.ting.ting.controller;
 
-import com.ting.ting.dto.BlindUsersInfoResponse;
+import com.ting.ting.dto.request.SendBlindRequest;
+import com.ting.ting.dto.response.BlindUsersInfoResponse;
+import com.ting.ting.service.BlindRequestService;
 import com.ting.ting.service.UserService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -13,13 +13,21 @@ import java.util.List;
 public class BlindDateController {
 
     private final UserService userService;
+    private final BlindRequestService blindRequestService;
 
-    public BlindDateController(UserService userService) {
+    public BlindDateController(UserService userService, BlindRequestService blindRequestService) {
         this.userService = userService;
+        this.blindRequestService = blindRequestService;
     }
 
     @GetMapping("users")
     public List<BlindUsersInfoResponse> blindUsersInfo() {
         return userService.usersInfo();
+    }
+
+    @PostMapping("/request")
+    public String sendBlindRequest(@RequestBody SendBlindRequest request) {
+        blindRequestService.createJoinRequest(request.getFromUserId(), request.getToUserId());
+        return "success";
     }
 }

--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -34,21 +34,21 @@ public class BlindDateController {
     }
 
     @PostMapping("/request")
-    public String sendBlindRequest(@RequestBody SendBlindRequest request) {
+    public ResponseEntity<String> sendBlindRequest(@RequestBody SendBlindRequest request) {
         blindRequestService.createJoinRequest(request.getFromUserId(), request.getToUserId());
-        return "success";
+        return ResponseEntity.ok("success");
     }
 
     @PutMapping("/request/{blindRequestId}")
-    public String rejectRequest(@PathVariable long blindRequestId) {
+    public ResponseEntity<String> rejectRequest(@PathVariable long blindRequestId) {
         blindRequestService.rejectRequest(blindRequestId);
-        return "success";
+        return ResponseEntity.ok("success");
     }
 
     @DeleteMapping("/request/{blindRequestId}")
-    public String deleteRequest(@PathVariable long blindRequestId) {
+    public ResponseEntity<String> deleteRequest(@PathVariable long blindRequestId) {
         blindRequestService.deleteRequest(blindRequestId);
-        return "success";
+        return ResponseEntity.ok("success");
     }
 
     @ExceptionHandler(UserException.class)

--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -39,6 +39,13 @@ public class BlindDateController {
         return "success";
     }
 
+    @PutMapping("/request/{blindRequestId}")
+    public String rejectRequest(@PathVariable long blindRequestId) {
+        blindRequestService.rejectRequest(blindRequestId);
+        return "success";
+    }
+
+
     @DeleteMapping("/request/{blindRequestId}")
     public String deleteRequest(@PathVariable long blindRequestId) {
         blindRequestService.deleteRequest(blindRequestId);

--- a/src/main/java/com/ting/ting/domain/BlindRequest.java
+++ b/src/main/java/com/ting/ting/domain/BlindRequest.java
@@ -1,0 +1,31 @@
+package com.ting.ting.domain;
+
+import com.ting.ting.domain.constant.RequestStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Setter
+@Getter
+@Table(name = "blind_request")
+@Entity
+public class BlindRequest {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user_id")
+    private User fromUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user_id")
+    private User toUser;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequestStatus status;
+}

--- a/src/main/java/com/ting/ting/domain/BlindRequest.java
+++ b/src/main/java/com/ting/ting/domain/BlindRequest.java
@@ -1,6 +1,5 @@
 package com.ting.ting.domain;
 
-import com.ting.ting.domain.constant.RequestStatus;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,9 +22,4 @@ public class BlindRequest {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_user_id")
     private User toUser;
-
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private RequestStatus status;
 }

--- a/src/main/java/com/ting/ting/domain/BlindRequest.java
+++ b/src/main/java/com/ting/ting/domain/BlindRequest.java
@@ -1,5 +1,6 @@
 package com.ting.ting.domain;
 
+import com.ting.ting.domain.constant.RequestStatus;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -22,4 +23,8 @@ public class BlindRequest {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_user_id")
     private User toUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequestStatus status;
 }

--- a/src/main/java/com/ting/ting/domain/constant/RequestStatus.java
+++ b/src/main/java/com/ting/ting/domain/constant/RequestStatus.java
@@ -1,7 +1,0 @@
-package com.ting.ting.domain.constant;
-
-public enum RequestStatus {
-    PENDING,
-    ACCEPTED,
-    REJECTED
-}

--- a/src/main/java/com/ting/ting/domain/constant/RequestStatus.java
+++ b/src/main/java/com/ting/ting/domain/constant/RequestStatus.java
@@ -1,0 +1,7 @@
+package com.ting.ting.domain.constant;
+
+public enum RequestStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/src/main/java/com/ting/ting/domain/constant/RequestStatus.java
+++ b/src/main/java/com/ting/ting/domain/constant/RequestStatus.java
@@ -1,0 +1,14 @@
+package com.ting.ting.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum RequestStatus {
+    P("요청중"),
+    S("성공"),
+    R("거절");
+
+    private final String status;
+}

--- a/src/main/java/com/ting/ting/dto/request/SendBlindRequest.java
+++ b/src/main/java/com/ting/ting/dto/request/SendBlindRequest.java
@@ -1,17 +1,25 @@
 package com.ting.ting.dto.request;
 
-import lombok.AllArgsConstructor;
+import com.ting.ting.exception.UserException;
 import lombok.Getter;
 
 import javax.validation.constraints.NotNull;
+import java.util.Objects;
 
 @Getter
-@AllArgsConstructor
 public class SendBlindRequest {
 
     @NotNull
-    private Long fromUserId;
+    private final Long fromUserId;
 
     @NotNull
-    private Long toUserId;
+    private final Long toUserId;
+
+    public SendBlindRequest(Long fromUserId, Long toUserId) {
+        this.fromUserId = fromUserId;
+        this.toUserId = toUserId;
+        if (Objects.equals(fromUserId, toUserId)) {
+            throw new UserException("같은 사용자간의 요청 처리입니다.");
+        }
+    }
 }

--- a/src/main/java/com/ting/ting/dto/request/SendBlindRequest.java
+++ b/src/main/java/com/ting/ting/dto/request/SendBlindRequest.java
@@ -1,0 +1,17 @@
+package com.ting.ting.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class SendBlindRequest {
+
+    @NotNull
+    private Long fromUserId;
+
+    @NotNull
+    private Long toUserId;
+}

--- a/src/main/java/com/ting/ting/dto/response/BlindUsersInfoResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/BlindUsersInfoResponse.java
@@ -1,4 +1,4 @@
-package com.ting.ting.dto;
+package com.ting.ting.dto.response;
 
 import com.ting.ting.domain.User;
 import com.ting.ting.domain.constant.MBTI;
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BlindUsersInfoResponse {
 
+    private Long id;
     private String school;
     private String major;
     private MBTI mbti;
@@ -16,6 +17,7 @@ public class BlindUsersInfoResponse {
     private float height;
 
     public BlindUsersInfoResponse(User user) {
+        this.id = user.getId();
         this.school = user.getSchool();
         this.major = user.getMajor();
         this.mbti = user.getMbti();

--- a/src/main/java/com/ting/ting/exception/DBException.java
+++ b/src/main/java/com/ting/ting/exception/DBException.java
@@ -1,9 +1,0 @@
-package com.ting.ting.exception;
-
-public class DBException extends IllegalArgumentException {
-
-    public DBException(String msg) {
-        super(msg);
-    }
-}
-

--- a/src/main/java/com/ting/ting/exception/DBException.java
+++ b/src/main/java/com/ting/ting/exception/DBException.java
@@ -1,0 +1,9 @@
+package com.ting.ting.exception;
+
+public class DBException extends IllegalArgumentException {
+
+    public DBException(String msg) {
+        super(msg);
+    }
+}
+

--- a/src/main/java/com/ting/ting/exception/UserException.java
+++ b/src/main/java/com/ting/ting/exception/UserException.java
@@ -1,0 +1,9 @@
+package com.ting.ting.exception;
+
+public class UserException extends IllegalArgumentException {
+
+    public UserException(String msg) {
+        super(msg);
+    }
+}
+

--- a/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
@@ -3,6 +3,9 @@ package com.ting.ting.repository;
 import com.ting.ting.domain.BlindRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BlindRequestRepository extends JpaRepository<BlindRequest, Long> {
+import java.util.Optional;
 
+public interface BlindRequestRepository extends JpaRepository<BlindRequest, Long> {
+    @Override
+    Optional<BlindRequest> findById(Long aLong);
 }

--- a/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
@@ -1,0 +1,8 @@
+package com.ting.ting.repository;
+
+import com.ting.ting.domain.BlindRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlindRequestRepository extends JpaRepository<BlindRequest, Long> {
+
+}

--- a/src/main/java/com/ting/ting/repository/UserRepository.java
+++ b/src/main/java/com/ting/ting/repository/UserRepository.java
@@ -1,17 +1,18 @@
 package com.ting.ting.repository;
 
 import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.Gender;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    @Override
-    List<User> findAll();
+    Page<User> findAllByGender(Gender gender, Pageable pageable);
 
     @Override
     Optional<User> findById(Long id);

--- a/src/main/java/com/ting/ting/repository/UserRepository.java
+++ b/src/main/java/com/ting/ting/repository/UserRepository.java
@@ -14,5 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAll();
 
     @Override
-    Optional<User> findById(Long aLong);
+    Optional<User> findById(Long id);
 }

--- a/src/main/java/com/ting/ting/service/BlindRequestService.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestService.java
@@ -2,6 +2,7 @@ package com.ting.ting.service;
 
 import com.ting.ting.domain.BlindRequest;
 import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.RequestStatus;
 import com.ting.ting.exception.UserException;
 import com.ting.ting.repository.BlindRequestRepository;
 import com.ting.ting.repository.UserRepository;
@@ -29,6 +30,7 @@ public class BlindRequestService {
         BlindRequest request = new BlindRequest();
         request.setFromUser(fromUser);
         request.setToUser(toUser);
+        request.setStatus(RequestStatus.P);
         blindRequestRepository.save(request);
     }
 }

--- a/src/main/java/com/ting/ting/service/BlindRequestService.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestService.java
@@ -2,7 +2,7 @@ package com.ting.ting.service;
 
 import com.ting.ting.domain.BlindRequest;
 import com.ting.ting.domain.User;
-import com.ting.ting.exception.DBException;
+import com.ting.ting.exception.UserException;
 import com.ting.ting.repository.BlindRequestRepository;
 import com.ting.ting.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -19,11 +19,11 @@ public class BlindRequestService {
     }
 
     public void createJoinRequest(long fromUserId, long toUserId) {
-        User fromUser = userRepository.findById(fromUserId).orElseThrow(() -> new DBException("잘못된 정보 입력"));
-        User toUser = userRepository.findById(toUserId).orElseThrow(() -> new DBException("잘못된 정보 입력"));
+        User fromUser = userRepository.findById(fromUserId).orElseThrow(() -> new UserException("해당 사용자의 정보가 존재하지 않습니다."));
+        User toUser = userRepository.findById(toUserId).orElseThrow(() -> new UserException("해당 사용자의 정보가 존재하지 않습니다."));
 
         if (fromUser.equals(toUser)) {
-            throw new DBException("잘못된 정보 입력");
+            throw new UserException("같은 사용자간의 요청 처리입니다.");
         }
 
         BlindRequest request = new BlindRequest();

--- a/src/main/java/com/ting/ting/service/BlindRequestService.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestService.java
@@ -33,4 +33,9 @@ public class BlindRequestService {
         request.setStatus(RequestStatus.P);
         blindRequestRepository.save(request);
     }
+
+    public void deleteRequest(long blindRequestId) {
+        BlindRequest request = blindRequestRepository.findById(blindRequestId).orElseThrow(() -> new UserException("해당 요청 정보가 존재하지 않습니다."));
+        blindRequestRepository.delete(request);
+    }
 }

--- a/src/main/java/com/ting/ting/service/BlindRequestService.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestService.java
@@ -23,10 +23,6 @@ public class BlindRequestService {
         User fromUser = userRepository.findById(fromUserId).orElseThrow(() -> new UserException("해당 사용자의 정보가 존재하지 않습니다."));
         User toUser = userRepository.findById(toUserId).orElseThrow(() -> new UserException("해당 사용자의 정보가 존재하지 않습니다."));
 
-        if (fromUser.equals(toUser)) {
-            throw new UserException("같은 사용자간의 요청 처리입니다.");
-        }
-
         BlindRequest request = new BlindRequest();
         request.setFromUser(fromUser);
         request.setToUser(toUser);

--- a/src/main/java/com/ting/ting/service/BlindRequestService.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestService.java
@@ -38,4 +38,10 @@ public class BlindRequestService {
         BlindRequest request = blindRequestRepository.findById(blindRequestId).orElseThrow(() -> new UserException("해당 요청 정보가 존재하지 않습니다."));
         blindRequestRepository.delete(request);
     }
+
+    public void acceptRequest(long blindRequestId) {
+        BlindRequest request = blindRequestRepository.findById(blindRequestId).orElseThrow(() -> new UserException("해당 요청 정보가 존재하지 않습니다."));
+        request.setStatus(RequestStatus.S);
+        blindRequestRepository.save(request);
+    }
 }

--- a/src/main/java/com/ting/ting/service/BlindRequestService.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestService.java
@@ -44,4 +44,10 @@ public class BlindRequestService {
         request.setStatus(RequestStatus.S);
         blindRequestRepository.save(request);
     }
+
+    public void rejectRequest(long blindRequestId) {
+        BlindRequest request = blindRequestRepository.findById(blindRequestId).orElseThrow(() -> new UserException("해당 요청 정보가 존재하지 않습니다."));
+        request.setStatus(RequestStatus.R);
+        blindRequestRepository.save(request);
+    }
 }

--- a/src/main/java/com/ting/ting/service/BlindRequestService.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestService.java
@@ -1,0 +1,34 @@
+package com.ting.ting.service;
+
+import com.ting.ting.domain.BlindRequest;
+import com.ting.ting.domain.User;
+import com.ting.ting.exception.DBException;
+import com.ting.ting.repository.BlindRequestRepository;
+import com.ting.ting.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BlindRequestService {
+
+    private final UserRepository userRepository;
+    private final BlindRequestRepository blindRequestRepository;
+
+    public BlindRequestService(UserRepository userRepository, BlindRequestRepository blindRequestRepository) {
+        this.userRepository = userRepository;
+        this.blindRequestRepository = blindRequestRepository;
+    }
+
+    public void createJoinRequest(long fromUserId, long toUserId) {
+        User fromUser = userRepository.findById(fromUserId).orElseThrow(() -> new DBException("잘못된 정보 입력"));
+        User toUser = userRepository.findById(toUserId).orElseThrow(() -> new DBException("잘못된 정보 입력"));
+
+        if (fromUser.equals(toUser)) {
+            throw new DBException("잘못된 정보 입력");
+        }
+
+        BlindRequest request = new BlindRequest();
+        request.setFromUser(fromUser);
+        request.setToUser(toUser);
+        blindRequestRepository.save(request);
+    }
+}

--- a/src/main/java/com/ting/ting/service/UserService.java
+++ b/src/main/java/com/ting/ting/service/UserService.java
@@ -1,7 +1,7 @@
 package com.ting.ting.service;
 
 import com.ting.ting.domain.User;
-import com.ting.ting.dto.BlindUsersInfoResponse;
+import com.ting.ting.dto.response.BlindUsersInfoResponse;
 import com.ting.ting.repository.UserRepository;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/ting/ting/service/UserService.java
+++ b/src/main/java/com/ting/ting/service/UserService.java
@@ -1,8 +1,11 @@
 package com.ting.ting.service;
 
 import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.Gender;
 import com.ting.ting.dto.response.BlindUsersInfoResponse;
 import com.ting.ting.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,8 +20,13 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public List<BlindUsersInfoResponse> usersInfo() {
-        List<User> users = userRepository.findAll();
+    public List<BlindUsersInfoResponse> womenUsersInfo(Pageable pageable) {
+        Page<User> users = userRepository.findAllByGender(Gender.W, pageable);
+        return users.stream().map(BlindUsersInfoResponse::new).collect(Collectors.toList());
+    }
+
+    public List<BlindUsersInfoResponse> menUsersInfo(Pageable pageable) {
+        Page<User> users = userRepository.findAllByGender(Gender.M, pageable);
         return users.stream().map(BlindUsersInfoResponse::new).collect(Collectors.toList());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,12 @@ spring:
     username: ${LOCAL_DB_USERNAME}
     password: ${LOCAL_DB_PASSWORD}
   sql.init.mode: always
+
   jpa:
     hibernate.ddl-auto: create
     show-sql: true
     defer-datasource-initialization: true
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher


### PR DESCRIPTION
swagger 연동 구현 완료했습니다.

버전은 2.9.2를 사용하였고 config파일을 추가해 swagger관련 설정 정보를 SwaggerConfig 클래스에 추가해서 구현하였습니다.
추가로, 

`org.springframework.context.ApplicationContextException: Failed to start bean 'documentationPluginsBootstrapper'; nested exception is java.lang.NullPointerException`

단순히 swagger를 사용하면 해당 오류가 뜨는 것을 확인하였습니다. 찾아보니 SpringBoot 2.6 버전 이후에 spring.mvc.pathmatch.matching-strategy 기본 값이 path_pattern_parser로 변경되어 생긴 문제였습니다. 따라서 application.yml 파일을 수정하여 오류를 해결하였습니다.
