### PR TITLE
[리팩토링] test를 위한 Fixture 도입

### DIFF
--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -56,7 +56,7 @@ public class GroupService {
     /**
      * 그룹 생성
      */
-    public void saveGroup(Long userId, GroupDto dto) {
+    public GroupDto saveGroup(Long userId, GroupDto dto) {
         User leader = loadUserByUserId(userId);
 
         groupRepository.findByGroupName(dto.getGroupName()).ifPresent(it -> {
@@ -65,7 +65,7 @@ public class GroupService {
 
         Group group = dto.toEntity(leader);
 
-        groupRepository.save(group);
+        return GroupDto.from(groupRepository.save(group));
     }
 
     /**

--- a/src/test/java/com/ting/ting/fixture/GroupFixture.java
+++ b/src/test/java/com/ting/ting/fixture/GroupFixture.java
@@ -1,0 +1,22 @@
+package com.ting.ting.fixture;
+
+import com.ting.ting.domain.Group;
+import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.Gender;
+import com.ting.ting.dto.GroupDto;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class GroupFixture {
+
+    public static Group entity(Long groupId) {
+        User leader = UserFixture.entity(groupId + 1);
+        Group entity = dto().toEntity(leader);
+        ReflectionTestUtils.setField(leader, "id", 1L);
+        return entity;
+    }
+
+    public static GroupDto dto() {
+        GroupDto dto = GroupDto.of("팀", Gender.W, 5, "단국대학교", "");
+        return dto;
+    }
+}

--- a/src/test/java/com/ting/ting/fixture/UserFixture.java
+++ b/src/test/java/com/ting/ting/fixture/UserFixture.java
@@ -1,0 +1,16 @@
+package com.ting.ting.fixture;
+
+import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.Gender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+public class UserFixture {
+
+    public static User entity(Long userId) {
+        User user = User.of("username", "email", "단국대학교", "통계학과", Gender.W, LocalDate.now());
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -3,12 +3,14 @@ package com.ting.ting.service;
 import com.ting.ting.domain.Group;
 import com.ting.ting.domain.GroupMemberRequest;
 import com.ting.ting.domain.User;
-import com.ting.ting.domain.constant.Gender;
 import com.ting.ting.dto.GroupDto;
+import com.ting.ting.fixture.GroupFixture;
+import com.ting.ting.fixture.UserFixture;
 import com.ting.ting.repository.GroupMemberRepository;
 import com.ting.ting.repository.GroupMemberRequestRepository;
 import com.ting.ting.repository.GroupRepository;
 import com.ting.ting.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,15 +19,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 
@@ -59,16 +58,16 @@ class GroupServiceTest {
     void givenUserId_whenSearchingMyGroups_thenReturnsGroupSet() {
         //Given
         Long userId = 1L;
-        User user = createUser(userId);
+        User user = UserFixture.entity(userId);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(groupMemberRepository.findGroupByMemberAndStatusAccepted(user)).willReturn(List.of(createGroup(2L)));
+        given(groupMemberRepository.findGroupByMemberAndStatusAccepted(user)).willReturn(List.of(GroupFixture.entity(1L), GroupFixture.entity(2L)));
 
         // When
         Set<GroupDto> groups = groupService.findMyGroupList(userId);
 
         // Then
-        assertThat(groups).hasSize(1);
+        assertThat(groups).hasSize(2);
     }
 
     @DisplayName("과팅 - 생성이 성공한 경우")
@@ -76,41 +75,36 @@ class GroupServiceTest {
     void givenUserIdAndGroupDto_WhenSavingGroup_thenSavesGroup() {
         //Given
         Long userId = 9L;
-        GroupDto dto = createGroupDto();
-        User user = createUser(userId);
+        GroupDto dto = GroupFixture.dto();
 
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        User leader = UserFixture.entity(userId);
+        Group entity = dto.toEntity(leader);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(leader));
         given(groupRepository.findByGroupName(dto.getGroupName())).willReturn(Optional.empty());
-        given(groupRepository.save(any(Group.class))).willReturn(any(Group.class));
+        given(groupRepository.save(any(Group.class))).willReturn(entity);
 
-        // When & Then
-        assertThatCode(() -> {
-            groupService.saveGroup(userId, dto);
-        }).doesNotThrowAnyException();
+        // When
+        GroupDto actual = groupService.saveGroup(userId, dto);
+
+        // Then
+        assertThat(actual.getGroupName()).isSameAs(entity.getGroupName());
     }
 
-    @DisplayName("과팅 - 멤버 가입 요청이 성공한 경우")
+    @DisplayName("과팅 - 멤버 가입 요청 기능 테스트")
     @Test
     void givenGroupIdAndUserId_whenRequestingJoin_thenSavesRequest() {
         //Given
         Long groupId = 1L;
-        Long userId = 2L;
-        Group group = createGroup(groupId);
-        User user = createUser(userId);
+        Long userId = 3L;
 
-        given(groupRepository.findById(groupId)).willReturn(Optional.of(group));
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(groupMemberRequestRepository.findByGroupAndUser(group, user)).willReturn(Optional.empty());
-        given(groupMemberRequestRepository.save(any(GroupMemberRequest.class))).willReturn(null);
+        given(groupRepository.findById(groupId)).willReturn(Optional.of(mock(Group.class)));
+        given(userRepository.findById(userId)).willReturn(Optional.of(mock(User.class)));
+        given(groupMemberRequestRepository.findByGroupAndUser(any(), any())).willReturn(Optional.empty());
+        given(groupMemberRequestRepository.save(any())).willReturn(any(GroupMemberRequest.class));
 
-        // When
-        groupService.saveJoinRequest(groupId, userId);
-
-        // Then
-        then(userRepository).should().findById(userId);
-        then(groupRepository).should().findById(groupId);
-        then(groupMemberRequestRepository).should().findByGroupAndUser(group, user);
-        then(groupMemberRequestRepository).should().save(any(GroupMemberRequest.class));
+        // When & Then
+        Assertions.assertDoesNotThrow(() -> groupService.saveJoinRequest(groupId, userId));
     }
 
     @DisplayName("과팅 - 멤버 가입 요청을 취소")
@@ -121,54 +115,7 @@ class GroupServiceTest {
         Long userId = 2L;
         willDoNothing().given(groupMemberRequestRepository).deleteByGroup_IdAndUser_Id(groupId, userId);
 
-        // When
-        groupService.deleteJoinRequest(groupId, userId);
-
-        // Then
-        then(groupMemberRequestRepository).should().deleteByGroup_IdAndUser_Id(groupId, userId);
-    }
-
-    private Group createGroup() {
-        return Group.of(
-                createUser(4L),
-                "팀 이름",
-                Gender.M,
-                "단국대학교",
-                3,
-                ""
-        );
-    }
-
-    private Group createGroup(Long id) {
-        Group group = createGroup();
-        ReflectionTestUtils.setField(group, "id", id);
-        return group;
-    }
-
-    private GroupDto createGroupDto() {
-        return GroupDto.of(
-                "팀 이름",
-                Gender.M,
-                3,
-                "단국대학교",
-                ""
-        );
-    }
-
-    private User createUser() {
-        return User.of(
-            "username",
-            "username@dankook.ac.kr",
-            "단국대학교",
-            "컴퓨터 공학과",
-            Gender.M,
-            LocalDate.now()
-        );
-    }
-
-    private User createUser(Long id) {
-        User user = createUser();
-        ReflectionTestUtils.setField(user, "id", id);
-        return user;
+        // When & Then
+        Assertions.assertDoesNotThrow(() -> groupService.deleteJoinRequest(groupId, userId));
     }
 }


### PR DESCRIPTION
기능 테스트를 위한 Group, User entity의 생성을 GroupServiceTest.class 에서 같이 처리를 했는데, 코드의 가독성을 위해서 따로 `GroupFixture`, `UserFixture` 를 만들어서 연결했습니다. 

이외에도 불필요한 데이터를 최소화하도록 수정했습니다. 

This relates to #46 , #47 

This closes #43 