### PR TITLE
[과팅] 팀 멤버 가입 요청 조회 기능

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -1,6 +1,7 @@
 package com.ting.ting.controller;
 
 import com.ting.ting.dto.request.GroupRequest;
+import com.ting.ting.dto.response.GroupMemberRequestResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
 import com.ting.ting.dto.response.GroupResponse;
 import com.ting.ting.dto.response.Response;
@@ -33,12 +34,6 @@ public interface GroupController {
     Response<Set<GroupMemberResponse>> getGroupMemberList(@PathVariable Long groupId);
 
     /**
-     * 팀장 넘기기
-     */
-    @PutMapping("/{groupId}/leader/{memberId}")
-    Response<Set<GroupMemberResponse>> changeGroupLeader(@PathVariable Long groupId, @PathVariable Long memberId);
-
-    /**
      * 그룹 생성
      */
     @PostMapping
@@ -55,4 +50,16 @@ public interface GroupController {
      */
     @DeleteMapping("/request/{groupId}")
     Response<Void> deleteJoinRequest(@PathVariable long groupId);
+
+    /**
+     * 팀장 넘기기
+     */
+    @PutMapping("/{groupId}/leader/{memberId}")
+    Response<Set<GroupMemberResponse>> changeGroupLeader(@PathVariable Long groupId, @PathVariable Long memberId);
+
+    /**
+     * 팀 멤버 가입 요청 조회
+     */
+    @GetMapping("/request/{groupId}")
+    Response<Set<GroupMemberRequestResponse>> getMemberRequestToJoinMyGroup(@PathVariable Long groupId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -1,6 +1,7 @@
 package com.ting.ting.controller;
 
 import com.ting.ting.dto.request.GroupRequest;
+import com.ting.ting.dto.response.GroupMemberRequestResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
 import com.ting.ting.dto.response.GroupResponse;
 import com.ting.ting.dto.response.Response;
@@ -27,7 +28,7 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Page<GroupResponse>> suggestedGroupList(@ParameterObject Pageable pageable) {
+    public Response<Page<GroupResponse>> suggestedGroupList(Pageable pageable) {
         return success(groupService.findAllGroups(pageable));
     }
 
@@ -38,24 +39,18 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Set<GroupMemberResponse>> getGroupMemberList(@PathVariable Long groupId) {
+    public Response<Set<GroupMemberResponse>> getGroupMemberList(Long groupId) {
         return success(groupService.findGroupMemberList(groupId));
     }
 
     @Override
-    public Response<Set<GroupMemberResponse>> changeGroupLeader(@PathVariable Long groupId, @PathVariable Long memberId) {
-        Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
-        return success(groupService.changeGroupLeader(groupId, leaderId, memberId));
-    }
-
-    @Override
-    public Response<GroupResponse> createGroup(@RequestBody GroupRequest request) {
+    public Response<GroupResponse> createGroup(GroupRequest request) {
         Long userId = 9L;  // userId를 임의로 설정 TODO: user 구현 후 수정
         return success(groupService.saveGroup(userId, request));
     }
 
     @Override
-    public Response<Void> sendJoinRequest(@PathVariable long groupId) {
+    public Response<Void> sendJoinRequest(long groupId) {
         Long userId = groupId + 1;  // userId를 임의로 설정 TODO: user 구현 후 수정
 
         groupService.saveJoinRequest(groupId, userId);
@@ -63,10 +58,22 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Void> deleteJoinRequest(@PathVariable long groupId) {
+    public Response<Void> deleteJoinRequest(long groupId) {
         Long userId = groupId + 1;  // userId를 임의로 설정 TODO: user 구현 후 수정
 
         groupService.deleteJoinRequest(groupId, userId);
         return success();
+    }
+
+    @Override
+    public Response<Set<GroupMemberResponse>> changeGroupLeader(Long groupId, Long memberId) {
+        Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+        return success(groupService.changeGroupLeader(groupId, leaderId, memberId));
+    }
+
+    @Override
+    public Response<Set<GroupMemberRequestResponse>> getMemberRequestToJoinMyGroup(Long groupId) {
+        Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+        return success(groupService.findMemberJoinRequest(groupId, leaderId));
     }
 }

--- a/src/main/java/com/ting/ting/dto/response/GroupMemberRequestResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupMemberRequestResponse.java
@@ -1,0 +1,23 @@
+package com.ting.ting.dto.response;
+
+import com.ting.ting.domain.GroupMemberRequest;
+import com.ting.ting.domain.constant.RequestStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GroupMemberRequestResponse {
+
+    private Long id;
+    private UserResponse user;
+    private RequestStatus requestStatus;
+
+    public static GroupMemberRequestResponse from(GroupMemberRequest entity) {
+        return new GroupMemberRequestResponse(
+                entity.getId(),
+                UserResponse.from(entity.getUser()),
+                entity.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/ting/ting/repository/GroupMemberRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupMemberRepository.java
@@ -12,14 +12,15 @@ import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
-    @Query(value = "select entity.group from GroupMember entity where entity.member = :user and entity.status = com.ting.ting.domain.constant.MemberStatus.ACTIVE")
-    List<Group> findAllGroupByMemberAndStatusActive(@Param("user") User user);
-
-    List<GroupMember> findAllByGroup(Group group);
-
-    @Query(value = "select entity from GroupMember entity where entity.group = :group and entity.status = com.ting.ting.domain.constant.MemberStatus.ACTIVE")
-    List<GroupMember> findAllByGroupAndStatusActive(@Param("group") Group group);
+    @Query(value = "select entity from GroupMember entity where entity.group = :group and entity.role = com.ting.ting.domain.constant.MemberRole.LEADER")
+    Optional<GroupMember> findByGroupWithRoleLeader(@Param("group") Group group);
 
     @Query(value = "select entity from GroupMember entity where entity.group = :group and entity.member = :user and entity.status = com.ting.ting.domain.constant.MemberStatus.ACTIVE")
-    Optional<GroupMember> findByGroupAndMemberAndStatusActive(@Param("group") Group group, @Param("user") User user);
+    Optional<GroupMember> findByGroupAndMemberWithStatusActive(@Param("group") Group group, @Param("user") User user);
+
+    @Query(value = "select entity from GroupMember entity join fetch entity.member where entity.group = :group")
+    List<GroupMember> findAllByGroup(@Param("group") Group group);
+
+    @Query(value = "select entity.group from GroupMember entity where entity.member = :user and entity.status = com.ting.ting.domain.constant.MemberStatus.ACTIVE")
+    List<Group> findAllGroupByMemberWithStatusActive(@Param("user") User user);
 }

--- a/src/main/java/com/ting/ting/repository/GroupMemberRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupMemberRequestRepository.java
@@ -4,7 +4,10 @@ import com.ting.ting.domain.Group;
 import com.ting.ting.domain.GroupMemberRequest;
 import com.ting.ting.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupMemberRequestRepository extends JpaRepository<GroupMemberRequest, Long> {
@@ -12,4 +15,7 @@ public interface GroupMemberRequestRepository extends JpaRepository<GroupMemberR
     Optional<GroupMemberRequest> findByGroupAndUser(Group group, User user);
 
     void deleteByGroup_IdAndUser_Id(Long groupId, Long userId);
+
+    @Query(value = "select entity from GroupMemberRequest entity join fetch entity.user where entity.group = :group")
+    List<GroupMemberRequest> findByGroup(@Param("group") Group group);
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -1,6 +1,7 @@
 package com.ting.ting.service;
 
 import com.ting.ting.dto.request.GroupRequest;
+import com.ting.ting.dto.response.GroupMemberRequestResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
 import com.ting.ting.dto.response.GroupResponse;
 import org.springframework.data.domain.Page;
@@ -49,4 +50,9 @@ public interface GroupService {
      * 팀장 넘기기
      */
     Set<GroupMemberResponse> changeGroupLeader(long groupId, long leaderId, long memberId);
+
+    /**
+     * 내가 팀장인 팀에 온 멤버 가입 요청을 조회
+     */
+    Set<GroupMemberRequestResponse> findMemberJoinRequest(long groupId, long leaderId);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -38,6 +38,11 @@ insert into group_member (group_id, member_id, status, role) values (7, 7, 'ACTI
 insert into group_member (group_id, member_id, status, role) values (8, 8, 'ACTIVE', 'LEADER');
 
 insert into group_member (group_id, member_id, status, role) values (1, 2, 'ACTIVE', 'MEMBER');
+insert into group_member (group_id, member_id, status, role) values (1, 3, 'PENDING', 'MEMBER');
 insert into group_member (group_id, member_id, status, role) values (3, 1, 'ACTIVE', 'MEMBER');
 insert into group_member (group_id, member_id, status, role) values (4, 1, 'ACTIVE', 'MEMBER');
 insert into group_member (group_id, member_id, status, role) values (5, 1, 'ACTIVE', 'MEMBER');
+
+insert into group_member_request (group_id, user_id) values (1, 3);
+insert into group_member_request (group_id, user_id) values (1, 4);
+insert into group_member_request (group_id, user_id) values (2, 3);


### PR DESCRIPTION
* https://github.com/realSolarDragons/back-end/issues/32 [- GroupMemberRequest entity의 Response 객체 정의](https://github.com/realSolarDragons/back-end/commit/2043a2d4df66bf2c22e00112592939f3fcd148ed)
* https://github.com/realSolarDragons/back-end/issues/32 [- data.sql : group_member_request 테이블 dummy data 추가](https://github.com/realSolarDragons/back-end/commit/bd2cafbda71f64f2af059a278ef43bb6eb14c8b1)
* https://github.com/realSolarDragons/back-end/issues/32 [- 과팅 팀 요청 조회 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/4378c3b8d6250a2e2a736f2d1e467069c29a313a)
     * 과팅 팀의 팀장만 조회할 수 있으므로 주어진 groupId를 가진 group의 팀장이 주어진 userId를 가진 user인지에 대한 검증 로직이 포함되어 있습니다.
* https://github.com/realSolarDragons/back-end/issues/32 [- 과팅 팀 요청 조회 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/b601119803fcebd6d9d322b481d124c00f23233b)
     * `GroupControllerImpl` 메소드에 있는 매개변수에 사용된 annotation들(ex `@PathVariable`, ..)은 필요가 없으므로 삭제합니다. `interface driven controller`(https://github.com/realSolarDragons/back-end/issues/27) 를 도입했을 때에는 해당 annotation들이 추가 정보를 준다고 생각되어서 제거하지 않았지만, 개발하다보니 인터페이스와 중복 정보가 덜 있는 구현 객체스럽게 만드는 게 나을 것 같아 제거합니다. 이는 기호에 따라 적용하면 될 것 같습니다!


This closes #32 