### PR TITLE
[과팅] 팀 멤버 가입 요청 수락 기능

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -54,12 +54,12 @@ public interface GroupController {
     /**
      * 팀장 넘기기
      */
-    @PutMapping("/{groupId}/leader/{memberId}")
-    Response<Set<GroupMemberResponse>> changeGroupLeader(@PathVariable Long groupId, @PathVariable Long memberId);
+    @PutMapping("/{groupId}/leader/{newLeaderId}")
+    Response<Set<GroupMemberResponse>> changeGroupLeader(@PathVariable Long groupId, @PathVariable Long newLeaderId);
 
     /**
      * 팀 멤버 가입 요청 조회
      */
-    @GetMapping("/request/{groupId}")
+    @GetMapping("/{groupId}/members/requests")
     Response<Set<GroupMemberRequestResponse>> getMemberRequestToJoinMyGroup(@PathVariable Long groupId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -62,4 +62,10 @@ public interface GroupController {
      */
     @GetMapping("/{groupId}/members/requests")
     Response<Set<GroupMemberRequestResponse>> getMemberRequestToJoinMyGroup(@PathVariable Long groupId);
+
+    /**
+     * 팀 멤버 가입 요청 수락
+     */
+    @PostMapping("members/requests/{groupMemberRequestId}")
+    Response<GroupMemberResponse> acceptJoinRequestToMyGroup(@PathVariable Long groupMemberRequestId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -74,4 +74,10 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
         Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
         return success(groupService.findMemberJoinRequest(groupId, leaderId));
     }
+
+    @Override
+    public Response<GroupMemberResponse> acceptJoinRequestToMyGroup(Long groupMemberRequestId) {
+        Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+        return success(groupService.acceptMemberJoinRequest(leaderId, groupMemberRequestId));
+    }
 }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -7,11 +7,9 @@ import com.ting.ting.dto.response.GroupResponse;
 import com.ting.ting.dto.response.Response;
 import com.ting.ting.exception.ServiceType;
 import com.ting.ting.service.GroupService;
-import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Set;
@@ -66,9 +64,9 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Set<GroupMemberResponse>> changeGroupLeader(Long groupId, Long memberId) {
+    public Response<Set<GroupMemberResponse>> changeGroupLeader(Long groupId, Long newLeaderId) {
         Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
-        return success(groupService.changeGroupLeader(groupId, leaderId, memberId));
+        return success(groupService.changeGroupLeader(groupId, leaderId, newLeaderId));
     }
 
     @Override

--- a/src/main/java/com/ting/ting/repository/GroupMemberRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupMemberRepository.java
@@ -3,6 +3,8 @@ package com.ting.ting.repository;
 import com.ting.ting.domain.Group;
 import com.ting.ting.domain.GroupMember;
 import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.MemberRole;
+import com.ting.ting.domain.constant.MemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,15 +14,16 @@ import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
-    @Query(value = "select entity from GroupMember entity where entity.group = :group and entity.role = com.ting.ting.domain.constant.MemberRole.LEADER")
-    Optional<GroupMember> findByGroupWithRoleLeader(@Param("group") Group group);
+    Optional<GroupMember> findByGroupAndRole(Group group, MemberRole role);
 
-    @Query(value = "select entity from GroupMember entity where entity.group = :group and entity.member = :user and entity.status = com.ting.ting.domain.constant.MemberStatus.ACTIVE")
-    Optional<GroupMember> findByGroupAndMemberWithStatusActive(@Param("group") Group group, @Param("user") User user);
+    Optional<GroupMember> findByGroupAndMemberAndStatus(Group group, User user, MemberStatus status);
 
     @Query(value = "select entity from GroupMember entity join fetch entity.member where entity.group = :group")
     List<GroupMember> findAllByGroup(@Param("group") Group group);
 
-    @Query(value = "select entity.group from GroupMember entity where entity.member = :user and entity.status = com.ting.ting.domain.constant.MemberStatus.ACTIVE")
-    List<Group> findAllGroupByMemberWithStatusActive(@Param("user") User user);
+    @Query(value = "select entity.group from GroupMember entity where entity.member = :user and entity.status = :status")
+    List<Group> findAllGroupByMemberAndStatus(@Param("user") User user, @Param("status") MemberStatus status);
+
+    @Query(value = "select entity.group from GroupMember entity where entity.member = :member and entity.role = :role")
+    Optional<Group> findGroupByMemberAndRole(@Param("member") User member, @Param("role") MemberRole role);
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -55,4 +55,9 @@ public interface GroupService {
      * 내가 팀장인 팀에 온 멤버 가입 요청을 조회
      */
     Set<GroupMemberRequestResponse> findMemberJoinRequest(long groupId, long leaderId);
+
+    /**
+     * 내가 팀장인 팀에 온 멤버 가입 요청을 수락
+     */
+    GroupMemberResponse acceptMemberJoinRequest(long leaderId, long groupMemberRequestId);
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -49,7 +49,7 @@ public interface GroupService {
     /**
      * 팀장 넘기기
      */
-    Set<GroupMemberResponse> changeGroupLeader(long groupId, long leaderId, long memberId);
+    Set<GroupMemberResponse> changeGroupLeader(long groupId, long leaderId, long newLeaderId);
 
     /**
      * 내가 팀장인 팀에 온 멤버 가입 요청을 조회

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -43,6 +43,6 @@ insert into group_member (group_id, member_id, status, role) values (3, 1, 'ACTI
 insert into group_member (group_id, member_id, status, role) values (4, 1, 'ACTIVE', 'MEMBER');
 insert into group_member (group_id, member_id, status, role) values (5, 1, 'ACTIVE', 'MEMBER');
 
-insert into group_member_request (group_id, user_id) values (1, 3);
+insert into group_member_request (group_id, user_id) values (1, 5);
 insert into group_member_request (group_id, user_id) values (1, 4);
 insert into group_member_request (group_id, user_id) values (2, 3);

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -189,4 +189,31 @@ class GroupServiceTest {
         // When & Then
         assertThat(groupService.findMemberJoinRequest(groupId, leaderId)).hasSize(2);
     }
+
+    @DisplayName("과팅 - [팀장] : 멤버 가입 요청 수락")
+    @Test
+    void givenLeaderIdAndGroupMemberRequestId_whenAcceptingMemberJoinRequest_thenReturnsCreatedGroupMemberResponse() {
+        //Given
+        Long leaderId = 1L;
+        Long groupMemberRequestId = 1L;
+
+        User leader = UserFixture.entity(leaderId);
+        User member = UserFixture.entity(leaderId + 1);
+        Group group = GroupFixture.entity(1L);
+        GroupMemberRequest groupMemberRequest = GroupMemberRequest.of(group, member);
+        GroupMember groupMember = GroupMember.of(group, member, MemberStatus.ACTIVE, MemberRole.MEMBER);
+
+        given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
+        given(groupMemberRequestRepository.findById(groupMemberRequestId)).willReturn(Optional.of(groupMemberRequest));
+        given(groupMemberRepository.findGroupByMemberAndRole(leader, MemberRole.LEADER)).willReturn(Optional.of(group));
+        given(groupMemberRepository.save(any())).willReturn(groupMember);
+
+        // When
+        GroupMemberResponse actual = groupService.acceptMemberJoinRequest(leaderId, groupMemberRequestId);
+
+        // Then
+        assertThat(actual.getMember().getUsername()).isSameAs(member.getUsername());
+        then(groupMemberRepository).should().save(any(GroupMember.class));
+        then(groupMemberRequestRepository).should().delete(any());
+    }
 }

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -61,7 +61,7 @@ class GroupServiceTest {
         User user = UserFixture.entity(userId);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(groupMemberRepository.findAllGroupByMemberWithStatusActive(user)).willReturn(List.of(GroupFixture.entity(1L), GroupFixture.entity(2L)));
+        given(groupMemberRepository.findAllGroupByMemberAndStatus(user, MemberStatus.ACTIVE)).willReturn(List.of(GroupFixture.entity(1L), GroupFixture.entity(2L)));
 
         // When & Then
         assertThat(groupService.findMyGroupList(userId)).hasSize(2);
@@ -155,8 +155,8 @@ class GroupServiceTest {
         given(groupRepository.findById(groupId)).willReturn(Optional.of(group));
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
         given(userRepository.findById(memberId)).willReturn(Optional.of(member));
-        given(groupMemberRepository.findByGroupAndMemberWithStatusActive(group, leader)).willReturn(Optional.of(groupLeaderRecord));
-        given(groupMemberRepository.findByGroupAndMemberWithStatusActive(group, member)).willReturn(Optional.of(groupMemberRecord));
+        given(groupMemberRepository.findByGroupAndMemberAndStatus(group, leader, MemberStatus.ACTIVE)).willReturn(Optional.of(groupLeaderRecord));
+        given(groupMemberRepository.findByGroupAndMemberAndStatus(group, member, MemberStatus.ACTIVE)).willReturn(Optional.of(groupMemberRecord));
         given(groupMemberRepository.saveAllAndFlush(List.of(groupLeaderRecord, groupMemberRecord))).willReturn(List.of(groupLeaderRecord, groupMemberRecord));
 
         // When
@@ -183,7 +183,7 @@ class GroupServiceTest {
 
         given(groupRepository.findById(groupId)).willReturn(Optional.of(group));
         given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
-        given(groupMemberRepository.findByGroupWithRoleLeader(group)).willReturn(Optional.of(groupLeaderRecord));
+        given(groupMemberRepository.findByGroupAndRole(group, MemberRole.LEADER)).willReturn(Optional.of(groupLeaderRecord));
         given(groupMemberRequestRepository.findByGroup(group)).willReturn(List.of(groupMemberRequest1, groupMemberRequest2));
 
         // When & Then


### PR DESCRIPTION
### 커밋 내용

*  [data.sql 변경](https://github.com/realSolarDragons/back-end/commit/47dd270220e5af7105e19b417927a061381917fb)
* [리팩토링: repository methods 수정 및 변경, changeGroupLeader()의 매개변수명 변경](https://github.com/realSolarDragons/back-end/commit/f40377ef748104f8dd86ea0c2b485aa753eedf43)
      * 리더가 넘기려고 하는 사용자의 id를 나타내는 변수명을 memberId -> newLeaderId 로 변경했습니다. 
      * repository method : enumType의 값을 @Query 를 이용해 미리 설정하는 형식으로 메소드를 선언했었는데, 확장성이 있도록 매개변수로 enumType을 받도록 수정했습니다. 
```java
/**
* 팀장 넘기기
*/
@PutMapping("/{groupId}/leader/{newLeaderId}")
Response<Set<GroupMemberResponse>> changeGroupLeader(@PathVariable Long groupId, @PathVariable Long memberId);
```
->
```java
/**
* 팀장 넘기기
*/
@PutMapping("/{groupId}/leader/{newLeaderId}")
Response<Set<GroupMemberResponse>> changeGroupLeader(@PathVariable Long groupId, @PathVariable Long newLeaderId);
```
* [멤버 가입 요청 수락 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/70f16f9adf704591d0fb5c1c820d48d6048c8f57)
     * 매개 변수로 `leaderId`, `groupMemberRequestId` 를 받습니다.
          1. 주어진 사용자가 팀장인 팀 조회
          2. 주어진 사용자가 팀장인 팀과 주어진 `GroupMemberRequest` 에 담겨 있는 팀과 같은지 확인
     -> 같다면, 주어진 사용자가 주어진 `GroupMemberRequest` 를 ACCEPT/REJECT 할 권한이 있음을 의미. 
     -> **이게 **정말 제대로** 동작하려면, 한 유저가 하나의 과팅 팀에서만 팀장을 할 수 있음이 보장되어야 합니다. 원래는 `Group` 에 `User leader` 라는 필드가 있어 DB단에서 unique 함을 보장할 수 있었습니다, (#31, #62) -  `leader` 필드 삭제로 인해 다른 방법을 도입해야 합니다. 이는 후에 이슈를 발급해서 처리하도록 하겠습니다.** 
* [리팩토링: @PathVariable 변수명 수정, mapping url 수정, unused import 삭제](https://github.com/realSolarDragons/back-end/commit/7ad87441442bb4266f5cef9699fb32b4b1fc6eb8)
* [팀 멤버 가입 요청 기능 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/fa1d11954d4a6b16d63d54a7a980a83bda6b9b4b)
     * 이 pr이 구현한 api는 팀장만 이용할 수 있는 api 입니다.  여기서 팀장의 id는 임의로 1L로 정의해뒀습니다.

This closes #33 