### PR TITLE
[과팅] 팀 멤버 가입 요청 거절 기능

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -68,4 +68,10 @@ public interface GroupController {
      */
     @PostMapping("members/requests/{groupMemberRequestId}")
     Response<GroupMemberResponse> acceptJoinRequestToMyGroup(@PathVariable Long groupMemberRequestId);
+
+    /**
+     * 팀 멤버 가입 요청 거절
+     */
+    @DeleteMapping("members/requests/{groupMemberRequestId}")
+    Response<Void> rejectJoinRequestToMyGroup(@PathVariable Long groupMemberRequestId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -80,4 +80,12 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
         Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
         return success(groupService.acceptMemberJoinRequest(leaderId, groupMemberRequestId));
     }
+
+    @Override
+    public Response<Void> rejectJoinRequestToMyGroup(Long groupMemberRequestId) {
+        Long leaderId = 1L;
+
+        groupService.rejectMemberJoinRequest(leaderId, groupMemberRequestId);
+        return success();
+    }
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -60,4 +60,9 @@ public interface GroupService {
      * 내가 팀장인 팀에 온 멤버 가입 요청을 수락
      */
     GroupMemberResponse acceptMemberJoinRequest(long leaderId, long groupMemberRequestId);
+
+    /**
+     * 내가 팀장인 팀에 온 멤버 가입 요청을 거절
+     */
+    void rejectMemberJoinRequest(long leaderId, long groupMemberRequestId);
 }

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -158,17 +158,37 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
         // 주어진 사용자가 팀장인 팀 조회
         Group group = groupMemberRepository.findGroupByMemberAndRole(leader, MemberRole.LEADER).orElseThrow(() ->
-            throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) has no permission regarding GroupMemberRequest(id: %d)", leaderId, groupMemberRequestId))
+            throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) is not the leader of Group(id: %d)", leaderId, groupMemberRequest.getGroup().getId()))
         );
 
         // 주어진 사용자가 팀장인 팀과 주어진 groupMemberRequest 의 팀이 일치하지 않는 경우 -> 에러
         if (!group.equals(groupMemberRequest.getGroup())) {
-            throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) has no permission regarding GroupMemberRequest(id: %d)", leaderId, groupMemberRequestId));
+            throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) is not the leader of Group(id: %d)", leaderId, groupMemberRequest.getGroup().getId()));
         }
 
         GroupMember created = groupMemberRepository.save(GroupMember.of(group, groupMemberRequest.getUser(), MemberStatus.ACTIVE, MemberRole.MEMBER));
         groupMemberRequestRepository.delete(groupMemberRequest);
         return GroupMemberResponse.from(created);
+    }
+
+    @Override
+    public void rejectMemberJoinRequest(long leaderId, long groupMemberRequestId) {
+        User leader = loadUserByUserId(leaderId);
+        GroupMemberRequest groupMemberRequest = groupMemberRequestRepository.findById(groupMemberRequestId).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("GroupMemberRequest(id: %d) not found", groupMemberRequestId))
+        );
+
+        // 주어진 사용자가 팀장인 팀 조회
+        Group group = groupMemberRepository.findGroupByMemberAndRole(leader, MemberRole.LEADER).orElseThrow(() ->
+                throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) is not the leader of Group(id: %d)", leaderId, groupMemberRequest.getGroup().getId()))
+        );
+
+        // 주어진 사용자가 팀장인 팀과 주어진 groupMemberRequest 의 팀이 일치하지 않는 경우 -> 에러
+        if (!group.equals(groupMemberRequest.getGroup())) {
+            throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) is not the leader of Group(id: %d)", leaderId, groupMemberRequest.getGroup().getId()));
+        }
+
+        groupMemberRequestRepository.delete(groupMemberRequest);
     }
 
     private Group loadGroupByGroupId(Long groupId) {

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -216,4 +216,26 @@ class GroupServiceTest {
         then(groupMemberRepository).should().save(any(GroupMember.class));
         then(groupMemberRequestRepository).should().delete(any());
     }
+
+    @DisplayName("과팅 - [팀장] : 멤버 가입 요청 수락 거절")
+    @Test
+    void givenLeaderIdAndGroupMemberRequestId_whenRejectingMemberJoinRequest_thenDeletesMemberJoinRequest() {
+        //Given
+        Long leaderId = 1L;
+        Long groupMemberRequestId = 1L;
+
+        User leader = UserFixture.entity(leaderId);
+        Group group = GroupFixture.entity(1L);
+        GroupMemberRequest groupMemberRequest = GroupMemberRequest.of(group, leader);
+
+        given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
+        given(groupMemberRequestRepository.findById(groupMemberRequestId)).willReturn(Optional.of(groupMemberRequest));
+        given(groupMemberRepository.findGroupByMemberAndRole(leader, MemberRole.LEADER)).willReturn(Optional.of(group));
+
+        // When
+        groupService.rejectMemberJoinRequest(leaderId, groupMemberRequestId);
+
+        // Then
+        then(groupMemberRequestRepository).should().delete(any());
+    }
 }


### PR DESCRIPTION
* [팀 멤버 가입 요청 거절 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/cacb06ee359104a18a6f839e79d00dffe854b583)
     * 로직은 팀 멤버 가입 요청 수락(https://github.com/realSolarDragons/back-end/issues/33 - https://github.com/realSolarDragons/back-end/commit/01bb95da72c66a367cb5df2723ceca333a65296e) 과 비슷합니다. 
* [팀 멤버 가입 요청 거절 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/5b1da1c875a999074a58d2ccf586a3a98f346f48)

### API 사용 예시
[POST] 
```
http://localhost:8080/groups/members/requests/{groupMemberRequestId}
```
`groupMemberRequestId` 의 `group_member_request` table 레코드를 삭제합니다.

레코드 삭제 대신에 request_status( `ACCEPTED`, `PENDING`, `REJECTED` ) 값을  컬럼 값을 `REJECTED` 로 update 
하는 방법도 있지만, 지금은 일단 레코드 삭제하는 방식으로 구현했습니다. 
추후에 추가 기능 사항에 status 의 `REJECTED` 값이 필요하면 로직을 바꿀 예정입니다. 


This closes #34 
