### PR TITLE
[소개팅] 상대편 조회 로직 수정

### DIFF
--- a/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
@@ -5,6 +5,7 @@ import com.ting.ting.domain.User;
 import com.ting.ting.domain.constant.RequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -18,4 +19,6 @@ public interface BlindRequestRepository extends JpaRepository<BlindRequest, Long
     Set<BlindRequest> findAllByFromUserAndStatus(User FromUser, RequestStatus status);
 
     Set<BlindRequest> findAllByToUserAndStatus(User toUser, RequestStatus status);
+
+    List<BlindRequest> findAllByFromUserOrToUser(User fromUser, User toUser);
 }

--- a/src/main/java/com/ting/ting/repository/UserRepository.java
+++ b/src/main/java/com/ting/ting/repository/UserRepository.java
@@ -8,11 +8,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Page<User> findAllByGender(Gender gender, Pageable pageable);
+    Page<User> findAllByGenderAndIdNotIn(Gender gender, Set<Long> usersId, Pageable pageable);
 
     @Override
     Optional<User> findById(Long id);


### PR DESCRIPTION
나와 관련된 상대편은 조회에 안나오도록 구현 완료 했습니다.

처음에 이런식으로 상대편이 조회됐는대,

<img width="1012" alt="스크린샷 2023-05-09 오후 2 30 07" src="https://user-images.githubusercontent.com/50222603/237003330-1f2c50b0-ee89-4563-8afc-8a10e165a9aa.png">

만약 내가 id 2, 3번 유저에 소개팅 요청을 보내게 되면,

해당 정보가 BlindRequest DB에 저장이되고

그 후 다시 상대편을 조회하게 되면,

<img width="1021" alt="스크린샷 2023-05-09 오후 2 30 25" src="https://user-images.githubusercontent.com/50222603/237003475-4ba9c3d6-be57-48a9-9070-4a1e81736dbf.png">

위와 같이 id 2, 3번 사용자들을 제외한 나머지 사용자들이 조회되는 것을 확인할 수 있습니다.

마찬가지로 다른 상대방이 나에게 요청을 보내게 되면 그 또한 상대편 조회 로직에서는 보이지 않게 구현하였습니다.

즉, BlindRequest에 나와 관련된 정보가 있을때 해당 상대편 정보는 소개팅 상대편 조회 페이지에 나오지 않게 구현하였습니다!!





