### PR TITLE
Feature/#35 team leader team meeting request select

### DIFF
--- a/src/main/java/com/ting/ting/AppConfig.java
+++ b/src/main/java/com/ting/ting/AppConfig.java
@@ -14,6 +14,7 @@ public class AppConfig {
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupMemberRequestRepository groupMemberRequestRepository;
+    private final GroupDateRequestRepository groupDateRequestRepository;
     private final BlindRequestRepository blindRequestRepository;
 
     @Bean
@@ -23,7 +24,7 @@ public class AppConfig {
 
     @Bean
     public GroupService groupService() {
-        return new GroupServiceImpl(groupRepository, groupMemberRepository, groupMemberRequestRepository, userRepository);
+        return new GroupServiceImpl(groupRepository, groupMemberRepository, groupMemberRequestRepository, groupDateRequestRepository, userRepository);
     }
 
     @Bean

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -1,10 +1,7 @@
 package com.ting.ting.controller;
 
 import com.ting.ting.dto.request.GroupRequest;
-import com.ting.ting.dto.response.GroupMemberRequestResponse;
-import com.ting.ting.dto.response.GroupMemberResponse;
-import com.ting.ting.dto.response.GroupResponse;
-import com.ting.ting.dto.response.Response;
+import com.ting.ting.dto.response.*;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -74,4 +71,10 @@ public interface GroupController {
      */
     @DeleteMapping("members/requests/{groupMemberRequestId}")
     Response<Void> rejectJoinRequestToMyGroup(@PathVariable Long groupMemberRequestId);
+
+    /**
+     * 다른 팀에게 온 미팅 요청 조회
+     */
+    @GetMapping("/{groupId}/dates/requests")
+    Response<Set<GroupDateRequestResponse>> getGroupDateRequest(@PathVariable Long groupId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -1,15 +1,11 @@
 package com.ting.ting.controller;
 
 import com.ting.ting.dto.request.GroupRequest;
-import com.ting.ting.dto.response.GroupMemberRequestResponse;
-import com.ting.ting.dto.response.GroupMemberResponse;
-import com.ting.ting.dto.response.GroupResponse;
-import com.ting.ting.dto.response.Response;
+import com.ting.ting.dto.response.*;
 import com.ting.ting.exception.ServiceType;
 import com.ting.ting.service.GroupService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Set;
@@ -87,5 +83,12 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
 
         groupService.rejectMemberJoinRequest(leaderId, groupMemberRequestId);
         return success();
+    }
+
+    @Override
+    public Response<Set<GroupDateRequestResponse>> getGroupDateRequest(Long groupId) {
+        Long leaderId = 1L;
+
+        return success(groupService.findAllGroupDataRequest(groupId, leaderId));
     }
 }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -89,6 +89,6 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     public Response<Set<GroupDateRequestResponse>> getGroupDateRequest(Long groupId) {
         Long leaderId = 1L;
 
-        return success(groupService.findAllGroupDataRequest(groupId, leaderId));
+        return success(groupService.findAllGroupDateRequest(groupId, leaderId));
     }
 }

--- a/src/main/java/com/ting/ting/domain/GroupDateRequest.java
+++ b/src/main/java/com/ting/ting/domain/GroupDateRequest.java
@@ -1,0 +1,51 @@
+package com.ting.ting.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+@Getter
+@Table(name = "\"group_date_request\"", uniqueConstraints = {
+        @UniqueConstraint(name = "unique_from_group_to_group", columnNames = {"from_id", "to_id"}),
+})
+@Entity
+public class GroupDateRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @JoinColumn(name = "from_id")
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Group fromGroup;
+
+    @NotNull
+    @JoinColumn(name = "to_id")
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Group toGroup;
+
+    protected GroupDateRequest() {}
+
+    private GroupDateRequest(Group fromGroup, Group toGroup) {
+        this.fromGroup = fromGroup;
+        this.toGroup = toGroup;
+    }
+
+    public static GroupDateRequest of(Group fromGroup, Group toGroup) {
+        return new GroupDateRequest(fromGroup, toGroup);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GroupDateRequest)) return false;
+        GroupDateRequest that = (GroupDateRequest) o;
+        return this.getId() != null && this.getId().equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() { return Objects.hash(this.getId()); }
+}

--- a/src/main/java/com/ting/ting/dto/response/GroupDateRequestResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupDateRequestResponse.java
@@ -1,0 +1,20 @@
+package com.ting.ting.dto.response;
+
+import com.ting.ting.domain.GroupDateRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GroupDateRequestResponse {
+
+    private Long id;
+    private GroupResponse fromGroup;
+
+    public static GroupDateRequestResponse from(GroupDateRequest entity) {
+        return new GroupDateRequestResponse(
+                entity.getId(),
+                GroupResponse.from(entity.getFromGroup())
+        );
+    }
+}

--- a/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
@@ -1,0 +1,15 @@
+package com.ting.ting.repository;
+
+import com.ting.ting.domain.Group;
+import com.ting.ting.domain.GroupDateRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface GroupDateRequestRepository extends JpaRepository<GroupDateRequest, Long> {
+
+    @Query(value = "select entity from GroupDateRequest entity join fetch entity.fromGroup where entity.toGroup = :toGroup")
+    List<GroupDateRequest> findByToGroup(@Param("toGroup") Group toGroup);
+}

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -1,6 +1,7 @@
 package com.ting.ting.service;
 
 import com.ting.ting.dto.request.GroupRequest;
+import com.ting.ting.dto.response.GroupDateRequestResponse;
 import com.ting.ting.dto.response.GroupMemberRequestResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
 import com.ting.ting.dto.response.GroupResponse;
@@ -65,4 +66,9 @@ public interface GroupService {
      * 내가 팀장인 팀에 온 멤버 가입 요청을 거절
      */
     void rejectMemberJoinRequest(long leaderId, long groupMemberRequestId);
+
+    /**
+     * 내가 팀장인 팀에 온 과팅 요청 조회
+     */
+    Set<GroupDateRequestResponse> findAllGroupDataRequest(long groupId, long leaderId);
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -70,5 +70,5 @@ public interface GroupService {
     /**
      * 내가 팀장인 팀에 온 과팅 요청 조회
      */
-    Set<GroupDateRequestResponse> findAllGroupDataRequest(long groupId, long leaderId);
+    Set<GroupDateRequestResponse> findAllGroupDateRequest(long groupId, long leaderId);
 }

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -167,7 +167,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public Set<GroupDateRequestResponse> findAllGroupDataRequest(long groupId, long leaderId) {
+    public Set<GroupDateRequestResponse> findAllGroupDateRequest(long groupId, long leaderId) {
         Group group = loadGroupByGroupId(groupId);
         User leader = loadUserByUserId(leaderId);
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -28,6 +28,11 @@ insert into `group` (id, group_name, gender, school, num_of_member, is_matched, 
 insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (7, '과팅팀7', 'WOMEN', '세종대학교', 2, false, '');
 insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (8, '과팅팀8', 'WOMEN', '홍익대학교', 4, false, '');
 
+insert into group_date_request(id, from_id, to_id) values (1, 2, 1);
+insert into group_date_request(id, from_id, to_id) values (2, 6, 1);
+insert into group_date_request(id, from_id, to_id) values (3, 7, 1);
+insert into group_date_request(id, from_id, to_id) values (4, 8, 1);
+
 insert into group_member (group_id, member_id, status, role) values (1, 1, 'ACTIVE', 'LEADER');
 insert into group_member (group_id, member_id, status, role) values (2, 2, 'ACTIVE', 'LEADER');
 insert into group_member (group_id, member_id, status, role) values (3, 3, 'ACTIVE', 'LEADER');

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -255,6 +255,6 @@ class GroupServiceTest {
         given(groupDateRequestRepository.findByToGroup(group)).willReturn(List.of(groupDateRequest1, groupDateRequest2));
 
         // When & Then
-        assertThat(groupService.findAllGroupDataRequest(groupId, leaderId)).hasSize(2);
+        assertThat(groupService.findAllGroupDateRequest(groupId, leaderId)).hasSize(2);
     }
 }


### PR DESCRIPTION
* [과팅 요청을 저장하는 테이블 정의](https://github.com/realSolarDragons/back-end/commit/f2d2cdc8071e8cde9dcb86f302468ff5f690fd3b)
     * `group_date_request` 테이블을 정의했습니다. 현재 과팅에서 request를 처리하는 로직(**request를 accept, reject하면 바로 삭제**)에서는 `request_status` 가 필요가 없으므로 일단 없이 구현하고, 추후에 다른 기능 추가로 필요하면 추가하려고 합니다.
     * data.sql 에 `group_date_request` 관련

* [과팅 요청 조회 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/8ab930e2bb1a270ea218ff9c105112b958cebad2)
     * `GroupDateRequestRepository` 추가로 AppConfig.java에 변경점이 생겼습니다.
     * 매개변수로 넘겨진 User가 매개변수로 넘겨진 Group의 팀장인지 확인하고 아니면 예외를 던지는 메소드 (`throwIfUserIsNotTheLeaderOfGroup`) 을 작성하고, 이전 코드에서 중복되는 코드를 대체했습니다.  이에 관련 서비스 테스트 코드에서도 변경점이 생겼습니다. 
     
* [과팅 요청 조회 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/b59e628a90b79dcc74b058e592d36ce978ac1e3e)

### API 사용 예시
[GET]
```java
http://localhost:8080/groups/{groupId}/dates/requests
```
이를 조회하는 팀장의 user Id 는 1L로 임의로 설정했습니다. 


This closes #35 
