### PR TITLE
[과팅] 과팅 요청 수락

### DIFF
--- a/src/main/java/com/ting/ting/AppConfig.java
+++ b/src/main/java/com/ting/ting/AppConfig.java
@@ -14,6 +14,7 @@ public class AppConfig {
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupMemberRequestRepository groupMemberRequestRepository;
+    private final GroupDateRepository groupDateRepository;
     private final GroupDateRequestRepository groupDateRequestRepository;
     private final BlindRequestRepository blindRequestRepository;
 
@@ -24,7 +25,7 @@ public class AppConfig {
 
     @Bean
     public GroupService groupService() {
-        return new GroupServiceImpl(groupRepository, groupMemberRepository, groupMemberRequestRepository, groupDateRequestRepository, userRepository);
+        return new GroupServiceImpl(groupRepository, groupMemberRepository, groupMemberRequestRepository, groupDateRepository, groupDateRequestRepository, userRepository);
     }
 
     @Bean

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -77,4 +77,10 @@ public interface GroupController {
      */
     @GetMapping("/{groupId}/dates/requests")
     Response<Set<GroupDateRequestResponse>> getGroupDateRequest(@PathVariable Long groupId);
+
+    /**
+     * 과팅 요청 수락
+     */
+    @PostMapping("/dates/requests/{groupDateRequestId}")
+    Response<GroupDateResponse> acceptGroupDateRequest(@PathVariable Long groupDateRequestId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -73,7 +73,7 @@ public interface GroupController {
     Response<Void> rejectJoinRequestToMyGroup(@PathVariable Long groupMemberRequestId);
 
     /**
-     * 다른 팀에게 온 미팅 요청 조회
+     * 과팅 요청 조회
      */
     @GetMapping("/{groupId}/dates/requests")
     Response<Set<GroupDateRequestResponse>> getGroupDateRequest(@PathVariable Long groupId);

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -91,4 +91,11 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
 
         return success(groupService.findAllGroupDateRequest(groupId, leaderId));
     }
+
+    @Override
+    public Response<GroupDateResponse> acceptGroupDateRequest(Long groupDateRequestId) {
+        Long leaderId = 1L;
+
+        return success(groupService.acceptGroupDateRequest(leaderId, groupDateRequestId));
+    }
 }

--- a/src/main/java/com/ting/ting/domain/GroupDate.java
+++ b/src/main/java/com/ting/ting/domain/GroupDate.java
@@ -1,0 +1,36 @@
+package com.ting.ting.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Table(name = "\"group_date\"", uniqueConstraints = {
+        @UniqueConstraint(name = "unique_men_group_women_group", columnNames = {"men_group_id", "women_group_id"}),
+})
+@Entity
+public class GroupDate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "men_group_id", unique = true)
+    @OneToOne(fetch = FetchType.LAZY)
+    private Group menGroup;
+
+    @JoinColumn(name = "women_group_id", unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Group womenGroup;
+
+    protected GroupDate() {}
+
+    private GroupDate(Group menGroup, Group womenGroup) {
+        this.menGroup = menGroup;
+        this.womenGroup = womenGroup;
+    }
+
+    public static GroupDate of(Group menGroup, Group womenGroup) {
+        return new GroupDate(menGroup, womenGroup);
+    }
+}

--- a/src/main/java/com/ting/ting/domain/GroupDateRequest.java
+++ b/src/main/java/com/ting/ting/domain/GroupDateRequest.java
@@ -3,8 +3,6 @@ package com.ting.ting.domain;
 import lombok.Getter;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
-import java.util.Objects;
 
 @Getter
 @Table(name = "\"group_date_request\"", uniqueConstraints = {
@@ -17,14 +15,12 @@ public class GroupDateRequest {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
     @JoinColumn(name = "from_id")
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Group fromGroup;
 
-    @NotNull
     @JoinColumn(name = "to_id")
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Group toGroup;
 
     protected GroupDateRequest() {}
@@ -37,15 +33,4 @@ public class GroupDateRequest {
     public static GroupDateRequest of(Group fromGroup, Group toGroup) {
         return new GroupDateRequest(fromGroup, toGroup);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GroupDateRequest)) return false;
-        GroupDateRequest that = (GroupDateRequest) o;
-        return this.getId() != null && this.getId().equals(that.getId());
-    }
-
-    @Override
-    public int hashCode() { return Objects.hash(this.getId()); }
 }

--- a/src/main/java/com/ting/ting/domain/GroupMemberRequest.java
+++ b/src/main/java/com/ting/ting/domain/GroupMemberRequest.java
@@ -44,16 +44,4 @@ public class GroupMemberRequest {
     public static GroupMemberRequest of(Group group, User user) {
         return new GroupMemberRequest(group, user);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GroupMemberRequest)) return false;
-        GroupMemberRequest that = (GroupMemberRequest) o;
-        return this.getUser() != null && this.getUser().getId().equals(that.getUser().getId())
-                && this.getGroup() != null && this.getGroup().getId().equals(that.getGroup().getId());
-    }
-
-    @Override
-    public int hashCode() { return Objects.hash(this.getId()); }
 }

--- a/src/main/java/com/ting/ting/dto/response/GroupDateResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupDateResponse.java
@@ -1,0 +1,22 @@
+package com.ting.ting.dto.response;
+
+import com.ting.ting.domain.GroupDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GroupDateResponse {
+
+    private Long id;
+    private GroupResponse menGroup;
+    private GroupResponse womenGroup;
+
+    public static GroupDateResponse from(GroupDate entity) {
+        return new GroupDateResponse(
+                entity.getId(),
+                GroupResponse.from(entity.getMenGroup()),
+                GroupResponse.from(entity.getWomenGroup())
+        );
+    }
+}

--- a/src/main/java/com/ting/ting/exception/ErrorCode.java
+++ b/src/main/java/com/ting/ting/exception/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
     DUPLICATED_REQUEST(HttpStatus.BAD_REQUEST, "Request information that already exists."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
     REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "Request information is not founded"),
-    GENDER_NOT_MATCH(HttpStatus.FORBIDDEN, "gender values do not match"),
+    GENDER_NOT_MATCH(HttpStatus.FORBIDDEN, "Gender values do not match"),
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "Permission is invalid")
     ;
 

--- a/src/main/java/com/ting/ting/repository/GroupDateRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupDateRepository.java
@@ -1,0 +1,10 @@
+package com.ting.ting.repository;
+
+import com.ting.ting.domain.Group;
+import com.ting.ting.domain.GroupDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupDateRepository extends JpaRepository<GroupDate, Long> {
+
+    boolean existsByMenGroupOrWomenGroup(Group menGroup, Group womenGroup);
+}

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -1,10 +1,7 @@
 package com.ting.ting.service;
 
 import com.ting.ting.dto.request.GroupRequest;
-import com.ting.ting.dto.response.GroupDateRequestResponse;
-import com.ting.ting.dto.response.GroupMemberRequestResponse;
-import com.ting.ting.dto.response.GroupMemberResponse;
-import com.ting.ting.dto.response.GroupResponse;
+import com.ting.ting.dto.response.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -71,4 +68,9 @@ public interface GroupService {
      * 내가 팀장인 팀에 온 과팅 요청 조회
      */
     Set<GroupDateRequestResponse> findAllGroupDateRequest(long groupId, long leaderId);
+
+    /**
+     * 내가 팀장인 팀에 온 과팅 요청 수락
+     */
+    GroupDateResponse acceptGroupDateRequest(long groupId, long groupDateRequestId);
 }

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -1,9 +1,11 @@
 package com.ting.ting.service;
 
 import com.ting.ting.domain.*;
+import com.ting.ting.domain.constant.Gender;
 import com.ting.ting.domain.constant.MemberRole;
 import com.ting.ting.domain.constant.MemberStatus;
 import com.ting.ting.dto.request.GroupRequest;
+import com.ting.ting.dto.response.GroupDateResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
 import com.ting.ting.dto.response.GroupResponse;
 import com.ting.ting.fixture.GroupFixture;
@@ -18,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.*;
 
@@ -34,6 +37,7 @@ class GroupServiceTest {
     @Mock private GroupRepository groupRepository;
     @Mock private GroupMemberRepository groupMemberRepository;
     @Mock private GroupMemberRequestRepository groupMemberRequestRepository;
+    @Mock private GroupDateRepository groupDateRepository;
     @Mock private GroupDateRequestRepository groupDateRequestRepository;
     @Mock private UserRepository userRepository;
 
@@ -213,7 +217,7 @@ class GroupServiceTest {
         then(groupMemberRequestRepository).should().delete(any());
     }
 
-    @DisplayName("과팅 - [팀장] : 멤버 가입 요청 수락 거절")
+    @DisplayName("과팅 - [팀장] : 멤버 가입 요청 거절")
     @Test
     void givenLeaderIdAndGroupMemberRequestId_whenRejectingMemberJoinRequest_thenDeletesMemberJoinRequest() {
         //Given
@@ -243,8 +247,8 @@ class GroupServiceTest {
         Long leaderId = 1L;
         Long groupId = 1L;
 
-        User leader = UserFixture.entity(1L);
-        Group group = GroupFixture.entity(1L);
+        User leader = UserFixture.entity(leaderId);
+        Group group = GroupFixture.entity(groupId);
         GroupMember memberRecordOfLeader = GroupMember.of(group, leader, MemberStatus.ACTIVE, MemberRole.LEADER);
         GroupDateRequest groupDateRequest1 = GroupDateRequest.of(GroupFixture.entity(2L), group);
         GroupDateRequest groupDateRequest2 = GroupDateRequest.of(GroupFixture.entity(3L), group);


### PR DESCRIPTION
* [과팅 저장하는 테이블 정의](https://github.com/realSolarDragons/back-end/commit/653915216ac95acc527b834a5549c5fc57a8515c)
     * 각 과팅 팀이 하나의 과팅만 진행함을 보장하기 위해 매칭되는 그룹을 `menGroup`, `womenGroup` 으로 나눴고 각 컬럼에 유니크 제약 조건을 설정했습니다.
  
* [과팅 요청 수락 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/ec8c3996efbb6a635647cabd775cc54478fe5ba7)
     * 수락하면  새로운`GroupDate` 를 저장하고, 기존의 `GroupDateRequest` 레코드를 삭제합니다. 
     * `GroupDate` 는 성별별로 그룹을 나눠서 저장(`menGroup`, `womenGroup`)하기 떄문에 `GroupDateRequest` 에서 각 그룹이 어떤 성별인지 구별하는 로직이 있습니다. 

* [과팅 요청 수락 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/b7caa0fa9c4c2adf956f816566401feb060bca2e)

* [리팩토링](https://github.com/realSolarDragons/back-end/commit/78581cc835d59a18aaf348771262da1d70fd2585)
     * (https://github.com/realSolarDragons/back-end/issues/35) : 과팅 요청 api javadoc 수정
     * (https://github.com/realSolarDragons/back-end/issues/35, https://github.com/realSolarDragons/back-end/issues/6) : `equals()` 와 `hashCode()`는 필요성이 확실해졌을 때 사용하려고 합니다. 서비스에서 영속, 영속 을 비교하는 경우가 많을지 영속, 준영속을 비교하는 경우가 많을지 아직 불확실하기 때문입니다.  (실무에선 id 값을 비교하는 방법을 많이 한다고 합니다. 또는 비즈니스 키 도입)
     * (https://github.com/realSolarDragons/back-end/issues/35) : 테스트 코드 DisplayName 잘못된 정보 수정
     * ErrorCode: 메세지 값이 모두 대문자로 시작하도록 수정했습니다.


### API 사용법
[POST]
```
/groups/dates/requests/{groupDateRequestId}
```
해당 api는 팀의 팀장만 사용할 수 있는 api 입니다. api를 이용하는 팀장의 user id 는 1L로 임의 설정했습니다.


This closes #36 
