### PR TITLE
[과팅] 과팅 요청 거절

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -83,4 +83,10 @@ public interface GroupController {
      */
     @PostMapping("/dates/requests/{groupDateRequestId}")
     Response<GroupDateResponse> acceptGroupDateRequest(@PathVariable Long groupDateRequestId);
+
+    /**
+     * 과팅 요청 거절
+     */
+    @DeleteMapping("/dates/requests/{groupDateRequestId}")
+    Response<Void> rejectGroupDateRequest(@PathVariable Long groupDateRequestId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -62,24 +62,27 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     @Override
     public Response<Set<GroupMemberResponse>> changeGroupLeader(Long groupId, Long newLeaderId) {
         Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
         return success(groupService.changeGroupLeader(groupId, leaderId, newLeaderId));
     }
 
     @Override
     public Response<Set<GroupMemberRequestResponse>> getMemberRequestToJoinMyGroup(Long groupId) {
         Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
         return success(groupService.findMemberJoinRequest(groupId, leaderId));
     }
 
     @Override
     public Response<GroupMemberResponse> acceptJoinRequestToMyGroup(Long groupMemberRequestId) {
         Long leaderId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
         return success(groupService.acceptMemberJoinRequest(leaderId, groupMemberRequestId));
     }
 
     @Override
     public Response<Void> rejectJoinRequestToMyGroup(Long groupMemberRequestId) {
-        Long leaderId = 1L;
+        Long leaderId = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 
         groupService.rejectMemberJoinRequest(leaderId, groupMemberRequestId);
         return success();
@@ -87,14 +90,14 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
 
     @Override
     public Response<Set<GroupDateRequestResponse>> getGroupDateRequest(Long groupId) {
-        Long leaderId = 1L;
+        Long leaderId = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 
         return success(groupService.findAllGroupDateRequest(groupId, leaderId));
     }
 
     @Override
     public Response<GroupDateResponse> acceptGroupDateRequest(Long groupDateRequestId) {
-        Long leaderId = 1L;
+        Long leaderId = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 
         return success(groupService.acceptGroupDateRequest(leaderId, groupDateRequestId));
     }

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -98,4 +98,12 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
 
         return success(groupService.acceptGroupDateRequest(leaderId, groupDateRequestId));
     }
+
+    @Override
+    public Response<Void> rejectGroupDateRequest(Long groupDateRequestId) {
+        Long leaderId = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        groupService.rejectGroupDateRequest(leaderId, groupDateRequestId);
+        return success();
+    }
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -72,7 +72,7 @@ public interface GroupService {
     /**
      * 내가 팀장인 팀에 온 과팅 요청 수락
      */
-    GroupDateResponse acceptGroupDateRequest(long groupId, long groupDateRequestId);
+    GroupDateResponse acceptGroupDateRequest(long leaderId, long groupDateRequestId);
 
     /**
      * 내가 팀장인 팀에 온 과팅 요청 거절

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -73,4 +73,9 @@ public interface GroupService {
      * 내가 팀장인 팀에 온 과팅 요청 수락
      */
     GroupDateResponse acceptGroupDateRequest(long groupId, long groupDateRequestId);
+
+    /**
+     * 내가 팀장인 팀에 온 과팅 요청 거절
+     */
+    void rejectGroupDateRequest(long leaderId, long groupDateRequestId);
 }

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -201,6 +201,18 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         return GroupDateResponse.from(created);
     }
 
+    @Override
+    public void rejectGroupDateRequest(long leaderId, long groupDateRequestId) {
+        User leader = loadUserByUserId(leaderId);
+        GroupDateRequest groupDateRequest = groupDateRequestRepository.findById(groupDateRequestId).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("GroupDateRequest(id: %d) not found", groupDateRequestId))
+        );
+
+        throwIfUserIsNotTheLeaderOfGroup(leader, groupDateRequest.getToGroup());
+
+        groupDateRequestRepository.delete(groupDateRequest);
+    }
+
     private void throwIfUserIsNotTheLeaderOfGroup(User leader, Group group) {
         // 과팅 팀의 팀장을 조회
         GroupMember memberRecordOfLeader = groupMemberRepository.findByGroupAndRole(group, MemberRole.LEADER).orElseThrow(() -> {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -19,13 +19,13 @@ insert into user (id, username, school, major, gender, birth, email, weight, hei
 insert into user (id, username, school, major, gender, birth, email, weight, height, ideal_photo, mbti) values (19, 'Gabie', 'Alsadrain University', 'Business Development', 'MEN', '2014-12-18', 'ggrayeri@forbes.com', 51, 147.2, 'http://dummyimage.com/246x100.png/ff4444/ffffff', 'INTP');
 insert into user (id, username, school, major, gender, birth, email, weight, height, ideal_photo, mbti) values (20, 'Celisse', 'Aleksander Gieysztor School of Humanities in Pultusk', 'Product Management', 'WOMEN', '1999-08-19', 'cmckeej@netlog.com', 82, 193.3, 'http://dummyimage.com/120x100.png/cc0000/ffffff', 'INFP');
 
-insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (1, '과팅팀1', 'MEN', '단국대학교', 3, false, '');
+insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (1, '과팅팀1', 'MEN', '단국대학교', 4, false, '');
 insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (2, '과팅팀2', 'WOMEN', '홍익대학교', 4, false, '');
-insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (3, '과팅팀3', 'MEN', '동국대학교', 2, false, '');
-insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (4, '과팅팀4', 'MEN', '서울대학교', 5, false, '');
+insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (3, '과팅팀3', 'MEN', '동국대학교', 4, false, '');
+insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (4, '과팅팀4', 'MEN', '서울대학교', 4, false, '');
 insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (5, '과팅팀5', 'MEN', '연세대학교', 4, false, '');
-insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (6, '과팅팀6', 'WOMEN', '건국대학교', 3, false, '');
-insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (7, '과팅팀7', 'WOMEN', '세종대학교', 2, false, '');
+insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (6, '과팅팀6', 'WOMEN', '건국대학교', 4, false, '');
+insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (7, '과팅팀7', 'WOMEN', '세종대학교', 4, false, '');
 insert into `group` (id, group_name, gender, school, num_of_member, is_matched, memo) values (8, '과팅팀8', 'WOMEN', '홍익대학교', 4, false, '');
 
 insert into group_date_request(id, from_id, to_id) values (1, 2, 1);

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -264,7 +264,7 @@ class GroupServiceTest {
 
     @DisplayName("과팅 - [팀장] : 과팅 요청 수락")
     @Test
-    void givenLeaderIdAndGroupDateRequestId_whenAcceptingGroupDateRequest_thenReturnsGroupDateResponse() {
+    void givenLeaderIdAndGroupDateRequestId_whenAcceptingGroupDateRequest_thenReturnsCreatedGroupDateResponse() {
         //Given
         Long leaderId = 1L;
         Long groupDateRequestId = 1L;

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -294,4 +294,26 @@ class GroupServiceTest {
         then(groupDateRepository).should().save(any(GroupDate.class));
         then(groupDateRequestRepository).should().delete(any());
     }
+
+    @DisplayName("과팅 - [팀장] : 과팅 요청 삭제")
+    @Test
+    void givenLeaderIdAndGroupDateRequestId_whenRejectingGroupDateRequest_thenDeletedGroupDateRequestRecord() {
+        //Given
+        Long leaderId = 1L;
+        Long groupDateRequestId = 1L;
+
+        User leader = UserFixture.entity(leaderId);
+        GroupDateRequest groupDateRequest = GroupDateRequest.of(GroupFixture.entity(1L), GroupFixture.entity(1L));
+        GroupMember memberRecordOfLeader = GroupMember.of(groupDateRequest.getToGroup(), leader, MemberStatus.ACTIVE, MemberRole.LEADER);
+
+        given(userRepository.findById(leaderId)).willReturn(Optional.of(leader));
+        given(groupDateRequestRepository.findById(groupDateRequestId)).willReturn(Optional.of(groupDateRequest));
+        given(groupMemberRepository.findByGroupAndRole(groupDateRequest.getToGroup(), MemberRole.LEADER)).willReturn(Optional.of(memberRecordOfLeader));
+
+        // When
+        groupService.rejectGroupDateRequest(leaderId, groupDateRequestId);
+
+        // Then
+        then(groupDateRequestRepository).should().delete(any());
+    }
 }


### PR DESCRIPTION
* [과팅 요청 거절 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/cc6dd175500301ec767cb1403bf82e70251ff78b)
* [과팅 요청 거절 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/f739e8d62e567609a6e2f1721159e009a5aa8584)
* [리팩토링](https://github.com/realSolarDragons/back-end/commit/4f4f2d8bba4e4725b9c4d88b0fa0c0aaaebb24e8)
      * (https://github.com/realSolarDragons/back-end/issues/36) service test method명 수정
      * (https://github.com/realSolarDragons/back-end/issues/36) service method 잘못된 매개변수명 수정
      * controller 코드 스타일 수정
      * data.sql 수정 
           * groupDateRequest는 같은 멤버수를 가지고 있는 팀끼리 가능하다고 가정하므로 더미데이터도 수정합니다. 추후 더 다양한 데이터를 추가할 예정입니다.

### API 상세
[DELETE]
```
/groups/dates/requests/{groupDateRequestId}
```

해당 api는 팀의 팀장만 사용할 수 있는 api 입니다. 이 api를 사용하는 팀장의 유저 id를 1L로 임의 설정했습니다. 

This closes #37 
