### PR TITLE
[소개팅] 요청 및 조회 수정

### DIFF
--- a/src/main/java/com/ting/ting/controller/BlindDateControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateControllerImpl.java
@@ -6,11 +6,8 @@ import com.ting.ting.dto.response.Response;
 import com.ting.ting.exception.ServiceType;
 import com.ting.ting.service.BlindRequestService;
 import lombok.extern.slf4j.Slf4j;
-import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -28,20 +25,20 @@ public class BlindDateControllerImpl extends AbstractController implements Blind
     }
 
     @Override
-    public Response<Page<BlindDateResponse>> blindUsersInfo(@ParameterObject Pageable pageable) {
+    public Response<Page<BlindDateResponse>> blindUsersInfo(Pageable pageable) {
         Long userId = 9L; // userId를 임의로 설정 TODO: user 구현 후 수정
         return success(blindRequestService.blindUsersInfo(userId, pageable));
     }
 
     @Override
-    public Response<Void> sendJoinRequest(@RequestBody SendBlindRequest request) {
+    public Response<Void> sendJoinRequest(SendBlindRequest request) {
         Long fromUserId = 9L;  // userId를 임의로 설정 TODO: user 구현 후 수정
         blindRequestService.createJoinRequest(fromUserId, request.getToUserId());
         return success();
     }
 
     @Override
-    public Response<Void> deleteJoinRequest(@PathVariable long blindRequestId) {
+    public Response<Void> deleteJoinRequest(long blindRequestId) {
         blindRequestService.deleteRequest(blindRequestId);
         return success();
     }
@@ -59,14 +56,14 @@ public class BlindDateControllerImpl extends AbstractController implements Blind
     }
 
     @Override
-    public Response<Void> acceptedRequest(@PathVariable long blindRequestId) {
+    public Response<Void> acceptedRequest(long blindRequestId) {
         Long userId = 9L; // userId를 임의로 설정 TODO: user 구현 후 수정
         blindRequestService.acceptRequest(userId, blindRequestId);
         return success();
     }
 
     @Override
-    public Response<Void> rejectRequest(@PathVariable long blindRequestId) {
+    public Response<Void> rejectRequest(long blindRequestId) {
         Long userId = 9L; // userId를 임의로 설정 TODO: user 구현 후 수정
         blindRequestService.rejectRequest(userId, blindRequestId);
         return success();

--- a/src/main/java/com/ting/ting/exception/ErrorCode.java
+++ b/src/main/java/com/ting/ting/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     GENDER_NOT_MATCH(HttpStatus.FORBIDDEN, "gender values do not match"),
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "Permission is invalid"),
     REACHED_MEMBERS_SIZE_LIMIT(HttpStatus.CONFLICT, "Maximum group capacity of the number of members reached"),
+    LIMIT_NUMBER_OF_REQUEST(HttpStatus.CONFLICT, "The maximum number of requests(5) has been exceeded."),
     REQUEST_NOT_MINE(HttpStatus.BAD_REQUEST,"This is not the request information that came to me"),
     
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");

--- a/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
@@ -20,4 +20,6 @@ public interface BlindRequestRepository extends JpaRepository<BlindRequest, Long
     Set<BlindRequest> findAllByToUserAndStatus(User toUser, RequestStatus status);
 
     Set<BlindRequest> findAllByToUser(User toUser);
+
+    Long countByFromUserAndStatus(User FromUser, RequestStatus status);
 }

--- a/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/BlindRequestRepository.java
@@ -18,4 +18,6 @@ public interface BlindRequestRepository extends JpaRepository<BlindRequest, Long
     Set<BlindRequest> findAllByFromUserAndStatus(User FromUser, RequestStatus status);
 
     Set<BlindRequest> findAllByToUserAndStatus(User toUser, RequestStatus status);
+
+    Set<BlindRequest> findAllByToUser(User toUser);
 }

--- a/src/main/java/com/ting/ting/repository/UserRepository.java
+++ b/src/main/java/com/ting/ting/repository/UserRepository.java
@@ -8,11 +8,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Page<User> findAllByGender(Gender gender, Pageable pageable);
+    Page<User> findAllByGenderAndIdNotIn(Gender gender, Set<Long> usersId, Pageable pageable);
 
     @Override
     Optional<User> findById(Long id);

--- a/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -36,14 +37,24 @@ public class BlindRequestServiceImpl extends AbstractService implements BlindReq
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new TingApplicationException(ErrorCode.USER_NOT_FOUND, ServiceType.BLIND, String.format("[%d]의 유저 정보가 존재하지 않습니다.", userId)));
 
-        return getBlindUsersInfo(user.getGender(), pageable);
+        return getBlindUsersInfo(user, pageable);
     }
 
-    private Page<BlindDateResponse> getBlindUsersInfo(Gender userGender, Pageable pageable) {
-        if (userGender == Gender.MEN) {
-            return userRepository.findAllByGender(Gender.WOMEN, pageable).map(BlindDateResponse::from);
+    private Page<BlindDateResponse> getBlindUsersInfo(User user, Pageable pageable) {
+        Set<Long> userIdOfRequestToMe = getUserIdOfRequestToMe(blindRequestRepository.findAllByToUser(user));
+
+        if (user.getGender() == Gender.MEN) {
+            return userRepository.findAllByGenderAndIdNotIn(Gender.WOMEN, userIdOfRequestToMe, pageable).map(BlindDateResponse::from);
         }
-        return userRepository.findAllByGender(Gender.MEN, pageable).map(BlindDateResponse::from);
+        return userRepository.findAllByGenderAndIdNotIn(Gender.MEN, userIdOfRequestToMe, pageable).map(BlindDateResponse::from);
+    }
+
+    private Set<Long> getUserIdOfRequestToMe(Set<BlindRequest> allByToUser) {
+        Set<Long> userIdOfRequestToMe = new HashSet<>();
+        for (BlindRequest user1 : allByToUser) {
+            userIdOfRequestToMe.add(user1.getFromUser().getId());
+        }
+        return userIdOfRequestToMe;
     }
 
     @Override

--- a/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
@@ -65,6 +65,11 @@ public class BlindRequestServiceImpl extends AbstractService implements BlindReq
 
         User fromUser = userRepository.findById(fromUserId).orElseThrow(() ->
                 throwException(ErrorCode.USER_NOT_FOUND, String.format("[%d]의 유저 정보가 존재하지 않습니다.", fromUserId)));
+
+        if (blindRequestRepository.countByFromUserAndStatus(fromUser, RequestStatus.PENDING) >= 5) {
+            throwException(ErrorCode.LIMIT_NUMBER_OF_REQUEST);
+        }
+
         User toUser = userRepository.findById(toUserId).orElseThrow(() ->
                 throwException(ErrorCode.USER_NOT_FOUND, String.format("[%d]의 유저 정보가 존재하지 않습니다.", toUserId)));
 
@@ -72,7 +77,7 @@ public class BlindRequestServiceImpl extends AbstractService implements BlindReq
             throwException(ErrorCode.DUPLICATED_REQUEST);
         });
 
-        if(fromUser.getGender() == toUser.getGender()) {
+        if (fromUser.getGender() == toUser.getGender()) {
             throwException(ErrorCode.GENDER_NOT_MATCH);
         }
 

--- a/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
@@ -72,6 +72,10 @@ public class BlindRequestServiceImpl extends AbstractService implements BlindReq
             throwException(ErrorCode.DUPLICATED_REQUEST);
         });
 
+        if(fromUser.getGender() == toUser.getGender()) {
+            throwException(ErrorCode.GENDER_NOT_MATCH);
+        }
+
         BlindRequest request = new BlindRequest();
         request.setFromUser(fromUser);
         request.setToUser(toUser);

--- a/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/BlindRequestServiceImpl.java
@@ -36,18 +36,13 @@ public class BlindRequestServiceImpl extends AbstractService implements BlindReq
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new TingApplicationException(ErrorCode.USER_NOT_FOUND, ServiceType.BLIND, String.format("[%d]의 유저 정보가 존재하지 않습니다.", userId)));
 
-        if (user.getGender().equals(Gender.MEN)) {
-            return womenBlindUsersInfo(pageable);
+        return getBlindUsersInfo(user.getGender(), pageable);
+    }
+
+    private Page<BlindDateResponse> getBlindUsersInfo(Gender userGender, Pageable pageable) {
+        if (userGender == Gender.MEN) {
+            return userRepository.findAllByGender(Gender.WOMEN, pageable).map(BlindDateResponse::from);
         }
-
-        return menBlindUsersInfo(pageable);
-    }
-
-    private Page<BlindDateResponse> womenBlindUsersInfo(Pageable pageable) {
-        return userRepository.findAllByGender(Gender.WOMEN, pageable).map(BlindDateResponse::from);
-    }
-
-    private Page<BlindDateResponse> menBlindUsersInfo(Pageable pageable) {
         return userRepository.findAllByGender(Gender.MEN, pageable).map(BlindDateResponse::from);
     }
 


### PR DESCRIPTION
1. 소개팅 조회 로직에서 소개팅 상대방이 나에게 요청을 보냈으면 해당 상대방 정보만 보이지 않게 조회 로직 변경
2. 소개팅 요청을 보낼때, 상대방의 성별 체크 로직 추가
3. 자신이 한번에 보낼 수 있는 소개팅 요청 횟수는 최대 5개로 제한
  - 이거 같은 경우 소개팅 요청이 성공할 경우 갯수가 1개 줄어듬
  - 즉, 내가 상대방에게 요청중인 상태가 최대 5개 가능
