### PR TITLE
[과팅] [팀장] 과팅 요청 기능

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -85,6 +85,12 @@ public interface GroupController {
     Response<Set<GroupDateRequestResponse>> getGroupDateRequest(@PathVariable Long groupId);
 
     /**
+     * 과팅 요청
+     */
+    @PostMapping("/{fromGroupId}/dates/requests/{toGroupId}")
+    Response<GroupDateRequestResponse> saveGroupDateRequest(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
+
+    /**
      * 과팅 요청 수락
      */
     @PostMapping("/dates/requests/{groupDateRequestId}")

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -105,6 +105,13 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
+    public Response<GroupDateRequestResponse> saveGroupDateRequest(Long fromGroupId, Long toGroupId) {
+        Long userIdOfLeader = 1L;
+
+        return success(groupService.saveGroupDateRequest(userIdOfLeader, fromGroupId, toGroupId));
+    }
+
+    @Override
     public Response<GroupDateResponse> acceptGroupDateRequest(Long groupDateRequestId) {
         Long userIdOfLeader = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 

--- a/src/main/java/com/ting/ting/dto/response/GroupDateRequestResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupDateRequestResponse.java
@@ -10,11 +10,13 @@ public class GroupDateRequestResponse {
 
     private Long id;
     private GroupResponse fromGroup;
+    private GroupResponse toGroup;
 
     public static GroupDateRequestResponse from(GroupDateRequest entity) {
         return new GroupDateRequestResponse(
                 entity.getId(),
-                GroupResponse.from(entity.getFromGroup())
+                GroupResponse.from(entity.getFromGroup()),
+                GroupResponse.from(entity.getToGroup())
         );
     }
 }

--- a/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
@@ -10,6 +10,10 @@ import java.util.List;
 
 public interface GroupDateRequestRepository extends JpaRepository<GroupDateRequest, Long> {
 
+    boolean existsByFromGroupAndToGroup(Group fromGroup, Group toGroup);
+
+    void deleteByFromGroupAndToGroup(Group fromGroup, Group toGroup);
+
     @Query(value = "select entity from GroupDateRequest entity join fetch entity.fromGroup where entity.toGroup = :toGroup")
     List<GroupDateRequest> findByToGroup(@Param("toGroup") Group toGroup);
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -75,6 +75,11 @@ public interface GroupService {
     Set<GroupDateRequestResponse> findAllGroupDateRequest(long groupId, long userIdOfLeader);
 
     /**
+     * 다른 팀에 과팅 요청
+     */
+    GroupDateRequestResponse saveGroupDateRequest(long userIdOfLeader, long fromGroupId, long toGroupId);
+
+    /**
      * 내가 팀장인 팀에 온 과팅 요청 수락
      */
     GroupDateResponse acceptGroupDateRequest(long userIdOfLeader, long groupDateRequestId);


### PR DESCRIPTION
* [다른 팀에 과팅 요청 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/bb0539a8e82521c241b033119bb80565b6477025)
     과팅 요청할 때 다음과 같은 유효성 검사를 합니다.
     * fromGroup과 toGroup이 다른 성별인지
     * 이미 fromGroup이 toGroup에 요청을 보낸 상태는 아닌지(toGroup이 fromGroup에 보냈는지는 확인하지 않습니다. 후에 두 팀 중 어떤 팀이 요청을 수락할 때 서로 요청한 레코드를 모두 삭제하기 떄문입니다.)(밑에 코드 블럭 참고해주세요!)
     * api를 사용한 유저가 fromGroup의 팀장인지
     * fromGroup과 toGroup 중 이미 매칭된 과팅을 가지고 있는 건 아닌지
```java
 groupDateRequestRepository.delete(groupDateRequest);
 groupDateRequestRepository.deleteByFromGroupAndToGroup(groupDateRequest.getToGroup(), groupDateRequest.getFromGroup()); // toGroup이 fromGroup에 요청한 적이 있다면, 그 기록도 삭제한다.
```

* [과팅 요청 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/2560360a057dee6c9e62ef6428c61fef133fd837)
     




This closes #78 