### PR TITLE
[과팅] [팀장] 과팅 요청 취소 기능

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -91,6 +91,12 @@ public interface GroupController {
     Response<GroupDateRequestResponse> saveGroupDateRequest(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
 
     /**
+     * 과팅 요청 취소
+     */
+    @DeleteMapping("/{fromGroupId}/dates/requests/{toGroupId}")
+    Response<Void> deleteGroupDateRequest(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
+
+    /**
      * 과팅 요청 수락
      */
     @PostMapping("/dates/requests/{groupDateRequestId}")

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -79,10 +79,10 @@ public interface GroupController {
     Response<Void> rejectJoinRequestToMyGroup(@PathVariable Long groupMemberRequestId);
 
     /**
-     * 과팅 요청 조회
+     * 과팅 요청 조회(받은 요청, 한 요청 모두)
      */
     @GetMapping("/{groupId}/dates/requests")
-    Response<Set<GroupDateRequestResponse>> getGroupDateRequest(@PathVariable Long groupId);
+    Response<GroupDateRequestWithFromAndToResponse> getGroupDateRequest(@PathVariable Long groupId);
 
     /**
      * 과팅 요청

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -112,6 +112,14 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
+    public Response<Void> deleteGroupDateRequest(Long fromGroupId, Long toGroupId) {
+        Long userIdOfLeader = 1L;
+
+        groupService.deleteGroupDateRequest(userIdOfLeader, fromGroupId, toGroupId);
+        return success();
+    }
+
+    @Override
     public Response<GroupDateResponse> acceptGroupDateRequest(Long groupDateRequestId) {
         Long userIdOfLeader = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -98,7 +98,7 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Set<GroupDateRequestResponse>> getGroupDateRequest(Long groupId) {
+    public Response<GroupDateRequestWithFromAndToResponse> getGroupDateRequest(Long groupId) {
         Long userIdOfLeader = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 
         return success(groupService.findAllGroupDateRequest(groupId, userIdOfLeader));

--- a/src/main/java/com/ting/ting/dto/response/GroupDateRequestWithFromAndToResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupDateRequestWithFromAndToResponse.java
@@ -9,6 +9,6 @@ import java.util.Set;
 @Getter
 public class GroupDateRequestWithFromAndToResponse {
 
-    private Set<GroupResponse> fromGroup;
-    private Set<GroupResponse> toGroup;
+    private Set<GroupResponse> receivedGroupDateRequests;
+    private Set<GroupResponse> sentGroupDateRequests;
 }

--- a/src/main/java/com/ting/ting/dto/response/GroupDateRequestWithFromAndToResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupDateRequestWithFromAndToResponse.java
@@ -1,0 +1,14 @@
+package com.ting.ting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Set;
+
+@AllArgsConstructor
+@Getter
+public class GroupDateRequestWithFromAndToResponse {
+
+    private Set<GroupResponse> fromGroup;
+    private Set<GroupResponse> toGroup;
+}

--- a/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
@@ -14,8 +14,8 @@ public interface GroupDateRequestRepository extends JpaRepository<GroupDateReque
 
     void deleteByFromGroupAndToGroup(Group fromGroup, Group toGroup);
 
-    @Query(value = "select entity from GroupDateRequest entity join fetch entity.fromGroup where entity.toGroup = :toGroup")
-    List<GroupDateRequest> findByToGroup(@Param("toGroup") Group toGroup);
+    void deleteByFromGroup_IdAndToGroup_Id(Long fromGroupId, Long toGroupId);
+
     @Query(value = "select distinct entity.fromGroup from GroupDateRequest entity join entity.fromGroup where entity.toGroup = :toGroup")
     List<Group> findFromGroupByToGroup(@Param("toGroup") Group toGroup);
 

--- a/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupDateRequestRepository.java
@@ -16,4 +16,9 @@ public interface GroupDateRequestRepository extends JpaRepository<GroupDateReque
 
     @Query(value = "select entity from GroupDateRequest entity join fetch entity.fromGroup where entity.toGroup = :toGroup")
     List<GroupDateRequest> findByToGroup(@Param("toGroup") Group toGroup);
+    @Query(value = "select distinct entity.fromGroup from GroupDateRequest entity join entity.fromGroup where entity.toGroup = :toGroup")
+    List<Group> findFromGroupByToGroup(@Param("toGroup") Group toGroup);
+
+    @Query(value = "select distinct entity.toGroup from GroupDateRequest entity join entity.toGroup where entity.fromGroup = :fromGroup")
+    List<Group> findToGroupByFromGroup(@Param("fromGroup") Group fromGroup);
 }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -80,6 +80,11 @@ public interface GroupService {
     GroupDateRequestResponse saveGroupDateRequest(long userIdOfLeader, long fromGroupId, long toGroupId);
 
     /**
+     * 다른 팀에 했던 과팅 요청을 취소
+     */
+    void deleteGroupDateRequest(long userIdOfLeader, long fromGroupId, long toGroupId);
+
+    /**
      * 내가 팀장인 팀에 온 과팅 요청 수락
      */
     GroupDateResponse acceptGroupDateRequest(long userIdOfLeader, long groupDateRequestId);

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -70,9 +70,9 @@ public interface GroupService {
     void rejectMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId);
 
     /**
-     * 내가 팀장인 팀에 온 과팅 요청 조회
+     * 내가 팀장인 팀이 한 과팅 요청과, 받은 과팅 요청 모두 조회
      */
-    Set<GroupDateRequestResponse> findAllGroupDateRequest(long groupId, long userIdOfLeader);
+    GroupDateRequestWithFromAndToResponse findAllGroupDateRequest(long groupId, long userIdOfLeader);
 
     /**
      * 다른 팀에 과팅 요청

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -255,6 +255,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
+    public void deleteGroupDateRequest(long userIdOfLeader, long fromGroupId, long toGroupId) {
+        User leader = loadUserByUserId(userIdOfLeader);
+        Group fromGroup = loadGroupByGroupId(fromGroupId);
+
+        throwIfUserIsNotTheLeaderOfGroup(leader, fromGroup);
+
+        groupDateRequestRepository.deleteByFromGroup_IdAndToGroup_Id(fromGroupId, toGroupId);
+    }
+
+    @Override
     public GroupDateResponse acceptGroupDateRequest(long userIdOfLeader, long groupDateRequestId) {
         User leader = loadUserByUserId(userIdOfLeader);
         Group menGroup, womenGroup;

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -210,13 +210,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public Set<GroupDateRequestResponse> findAllGroupDateRequest(long groupId, long userIdOfLeader) {
+    public GroupDateRequestWithFromAndToResponse findAllGroupDateRequest(long groupId, long userIdOfLeader) {
         Group group = loadGroupByGroupId(groupId);
         User leader = loadUserByUserId(userIdOfLeader);
 
         throwIfUserIsNotTheLeaderOfGroup(leader, group);
 
-        return groupDateRequestRepository.findByToGroup(group).stream().map(GroupDateRequestResponse::from).collect(Collectors.toUnmodifiableSet());
+        Set<GroupResponse> requestsFromThisGroup = groupDateRequestRepository.findToGroupByFromGroup(group).stream().map(GroupResponse::from).collect(Collectors.toUnmodifiableSet());
+        Set<GroupResponse> requestsToThisGroup = groupDateRequestRepository.findFromGroupByToGroup(group).stream().map(GroupResponse::from).collect(Collectors.toUnmodifiableSet());
+
+        return new GroupDateRequestWithFromAndToResponse(requestsFromThisGroup, requestsToThisGroup);
     }
 
     @Override

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -216,10 +216,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
         throwIfUserIsNotTheLeaderOfGroup(leader, group);
 
-        Set<GroupResponse> requestsFromThisGroup = groupDateRequestRepository.findToGroupByFromGroup(group).stream().map(GroupResponse::from).collect(Collectors.toUnmodifiableSet());
-        Set<GroupResponse> requestsToThisGroup = groupDateRequestRepository.findFromGroupByToGroup(group).stream().map(GroupResponse::from).collect(Collectors.toUnmodifiableSet());
+        Set<GroupResponse> receivedGroupDateRequests = groupDateRequestRepository.findFromGroupByToGroup(group).stream().map(GroupResponse::from).collect(Collectors.toUnmodifiableSet());
+        Set<GroupResponse> sentGroupDateRequests = groupDateRequestRepository.findToGroupByFromGroup(group).stream().map(GroupResponse::from).collect(Collectors.toUnmodifiableSet());
 
-        return new GroupDateRequestWithFromAndToResponse(requestsFromThisGroup, requestsToThisGroup);
+        return new GroupDateRequestWithFromAndToResponse(receivedGroupDateRequests, sentGroupDateRequests);
     }
 
     @Override

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -44,6 +44,8 @@ insert into group_date_request(id, from_id, to_id) values (1, 2, 1);
 insert into group_date_request(id, from_id, to_id) values (2, 6, 1);
 insert into group_date_request(id, from_id, to_id) values (3, 7, 1);
 insert into group_date_request(id, from_id, to_id) values (4, 8, 1);
+insert into group_date_request(id, from_id, to_id) values (5, 1, 16);
+insert into group_date_request(id, from_id, to_id) values (6, 1, 19);
 
 insert into group_member (group_id, member_id, status, role) values (1, 1, 'ACTIVE', 'LEADER');
 insert into group_member (group_id, member_id, status, role) values (2, 2, 'ACTIVE', 'LEADER');

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -506,6 +506,24 @@ class GroupServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REQUEST);
     }
 
+    @DisplayName("[팀장] : 과팅 요청 취소 기능 테스트")
+    @Test
+    void Given_FromGroupAndToGroup_When_DeleteGroupDateRequest_Then_DeletesGroupDateRequest() {
+        //Given
+        Long fromGroupId = 1L;
+        Long toGroupId = 2L;
+
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(groupRepository.findById(any())).willReturn(Optional.of(mock(Group.class)));
+        given(groupMemberRepository.existsByGroupAndMemberAndStatusAndRole(any(), any(), any(), any())).willReturn(true);
+
+        //When
+        groupService.deleteGroupDateRequest(user.getId(), fromGroupId, toGroupId);
+
+        //Then
+        then(groupDateRequestRepository).should().deleteByFromGroup_IdAndToGroup_Id(any(), any());
+    }
+
     @DisplayName("[팀장] : 과팅 요청 수락 기능 테스트")
     @Test
     void Given_GroupDateRequest_When_AcceptGroupDateRequest_Then_ReturnsCreatedGroupDateResponse() {

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -6,6 +6,7 @@ import com.ting.ting.domain.constant.MemberRole;
 import com.ting.ting.domain.constant.MemberStatus;
 import com.ting.ting.dto.request.GroupRequest;
 import com.ting.ting.dto.response.GroupDateRequestResponse;
+import com.ting.ting.dto.response.GroupDateRequestWithFromAndToResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
 import com.ting.ting.dto.response.GroupResponse;
 import com.ting.ting.exception.ErrorCode;
@@ -438,16 +439,19 @@ class GroupServiceTest {
         Long groupId = 1L;
 
         Group group = GroupFixture.createGroupById(groupId);
-        GroupDateRequest request1 = GroupDateRequest.of(GroupFixture.createGroupById(2L), group);
-        GroupDateRequest request2 = GroupDateRequest.of(GroupFixture.createGroupById(3L), group);
 
         given(groupRepository.findById(any())).willReturn(Optional.of(mock(Group.class)));
         given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
         given(groupMemberRepository.existsByGroupAndMemberAndStatusAndRole(any(), any(), any(), any())).willReturn(true);
-        given(groupDateRequestRepository.findByToGroup(any())).willReturn(List.of(request1, request2));
+        given(groupDateRequestRepository.findToGroupByFromGroup(any())).willReturn(List.of(GroupFixture.createGroupById(4L), GroupFixture.createGroupById(5L), GroupFixture.createGroupById(6L)));
+        given(groupDateRequestRepository.findFromGroupByToGroup(any())).willReturn(List.of(GroupFixture.createGroupById(2L), GroupFixture.createGroupById(3L)));
 
-        //When & Then
-        assertThat(groupService.findAllGroupDateRequest(groupId, user.getId())).hasSize(2);
+        //When
+        GroupDateRequestWithFromAndToResponse created = groupService.findAllGroupDateRequest(groupId, user.getId());
+
+        //Then
+        assertThat(created.getFromGroup()).hasSize(3);
+        assertThat(created.getToGroup()).hasSize(2);
     }
 
     @DisplayName("[팀장] : 과팅 요청 기능 테스트")


### PR DESCRIPTION
### [과팅 요청 조회 로직 수정](https://github.com/realSolarDragons/back-end/commit/344456e61976637b23eeaf767177e04fe7d89982)

기존에는 팀장이 과팅 요청 조회 api를 사용하면, 본인 팀에게 온 요청만 보였습니다. 이를 본인 팀에게 온 요청 + 본인 팀이 했던 요청을 한 번에 볼 수 있도록 수정했습니다.

<img src="https://github.com/realSolarDragons/back-end/assets/83967710/478cd027-7bbf-4f8d-975f-137c576b2cc8" width="50%" height="30%"/>


-> 이렇게 수정되었습니다. `receivedGroupDateRequests` 과 `sentGroupDateRequests` 로 나타내기 위해 `GroupDateRequestWithFromAndToResponse` response도 새로 정의했습니다. 


### [과팅 요청 취소 비즈니스 로직 구현](https://github.com/realSolarDragons/back-end/commit/5e7cea33d978c52c51d671db8dd6d6a46cee60aa)

삭제 시에는 삭제할 record가 없어도 오류가 나지 않으므로 `fromGroup` 과 `userIdOfLeader`에 대한 유효성 검사(1. fromGroup이 존재하는 group인지, 2. user가 fromGroup의 팀장이 많는지)만 하고 fromGroupId와 toGroupId로 delete 를 합니다. 

### [과팅 요청 취소 기능 컨트롤러 구현](https://github.com/realSolarDragons/back-end/commit/1e99352680001f22b69513da88417c465d8eb3e5)
[DELETE]
```
/groups/{fromGroupId}/dates/requests/{toGroupId}
```
해당 api는 한 과팅팀의 팀장만 사용할 수 있는 api며, 팀장의 userId 는 1L로 임의 설정 해둔 상태입니다.


This closes #79 