### PR TITLE
Feature/#90 blind change search

### DIFF
--- a/src/main/java/com/ting/ting/controller/BlindDateController.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateController.java
@@ -1,15 +1,13 @@
 package com.ting.ting.controller;
 
 import com.ting.ting.dto.request.SendBlindRequest;
-import com.ting.ting.dto.response.BlindDateResponse;
+import com.ting.ting.dto.response.BlindRequestWithFromAndToResponse;
 import com.ting.ting.dto.response.BlindUserWithRequestStatusResponse;
 import com.ting.ting.dto.response.Response;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RequestMapping("/blind")
 public interface BlindDateController {
@@ -33,16 +31,10 @@ public interface BlindDateController {
     Response<Void> deleteJoinRequest(@PathVariable long blindRequestId);
 
     /**
-     * 내가 한 요청 확인
+     * 소개팅 요청 조회(받은 요청, 한 요청 모두)
      */
-    @GetMapping("/confirm/myRequest")
-    Response<List<BlindDateResponse>> confirmOfMyRequest();
-
-    /**
-     * 나에게 온 요청 확인
-     */
-    @GetMapping("/confirm/request/toMe")
-    Response<List<BlindDateResponse>> confirmOfRequestToMe();
+    @GetMapping("/requests")
+    Response<BlindRequestWithFromAndToResponse> getBlindRequest();
 
     /**
      * 자신에게 온 요청 수락

--- a/src/main/java/com/ting/ting/controller/BlindDateControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/BlindDateControllerImpl.java
@@ -2,7 +2,7 @@ package com.ting.ting.controller;
 
 import com.ting.ting.domain.constant.RequestStatus;
 import com.ting.ting.dto.request.SendBlindRequest;
-import com.ting.ting.dto.response.BlindDateResponse;
+import com.ting.ting.dto.response.BlindRequestWithFromAndToResponse;
 import com.ting.ting.dto.response.BlindUserWithRequestStatusResponse;
 import com.ting.ting.dto.response.Response;
 import com.ting.ting.exception.ServiceType;
@@ -11,9 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -46,15 +43,9 @@ public class BlindDateControllerImpl extends AbstractController implements Blind
     }
 
     @Override
-    public Response<List<BlindDateResponse>> confirmOfMyRequest() {
+    public Response<BlindRequestWithFromAndToResponse> getBlindRequest() {
         Long userId = 9L; // userId를 임의로 설정 TODO: user 구현 후 수정
-        return success(blindService.myRequest(userId).stream().collect(Collectors.toUnmodifiableList()));
-    }
-
-    @Override
-    public Response<List<BlindDateResponse>> confirmOfRequestToMe() {
-        Long userId = 9L; // userId를 임의로 설정 TODO: user 구현 후 수정
-        return success(blindService.requestToMe(userId).stream().collect(Collectors.toUnmodifiableList()));
+        return success(blindService.getBlindRequest(userId));
     }
 
     @Override

--- a/src/main/java/com/ting/ting/dto/response/BlindRequestWithFromAndToResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/BlindRequestWithFromAndToResponse.java
@@ -1,0 +1,14 @@
+package com.ting.ting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Set;
+
+@AllArgsConstructor
+@Getter
+public class BlindRequestWithFromAndToResponse {
+
+    private Set<BlindDateResponse> receivedBlindRequests;
+    private Set<BlindDateResponse> sendBlindRequests;
+}

--- a/src/main/java/com/ting/ting/service/BlindService.java
+++ b/src/main/java/com/ting/ting/service/BlindService.java
@@ -1,12 +1,10 @@
 package com.ting.ting.service;
 
 import com.ting.ting.domain.constant.RequestStatus;
-import com.ting.ting.dto.response.BlindDateResponse;
+import com.ting.ting.dto.response.BlindRequestWithFromAndToResponse;
 import com.ting.ting.dto.response.BlindUserWithRequestStatusResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import java.util.Set;
 
 public interface BlindService {
 
@@ -26,14 +24,9 @@ public interface BlindService {
     void deleteRequest(long blindRequestId);
 
     /**
-     * 내가 한 요청 확인
+     * 소개팅 요청 조회(받은 요청, 한 요청 모두)
      */
-    Set<BlindDateResponse> myRequest(long fromUserId);
-
-    /**
-     * 나에게 온 요청 확인
-     */
-    Set<BlindDateResponse> requestToMe(long toUserId);
+    BlindRequestWithFromAndToResponse getBlindRequest(long userId);
 
     /**
      * 자신에게 온 요청 수락 & 거절

--- a/src/main/java/com/ting/ting/service/BlindServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/BlindServiceImpl.java
@@ -6,6 +6,7 @@ import com.ting.ting.domain.User;
 import com.ting.ting.domain.constant.Gender;
 import com.ting.ting.domain.constant.RequestStatus;
 import com.ting.ting.dto.response.BlindDateResponse;
+import com.ting.ting.dto.response.BlindRequestWithFromAndToResponse;
 import com.ting.ting.dto.response.BlindUserWithRequestStatusResponse;
 import com.ting.ting.exception.ErrorCode;
 import com.ting.ting.exception.ServiceType;
@@ -131,7 +132,14 @@ public class BlindServiceImpl extends AbstractService implements BlindService {
     }
 
     @Override
-    public Set<BlindDateResponse> myRequest(long fromUserId) {
+    public BlindRequestWithFromAndToResponse getBlindRequest(long userId) {
+        return new BlindRequestWithFromAndToResponse(
+                requestToMe(userId),
+                myRequest(userId)
+        );
+    }
+
+    private Set<BlindDateResponse> myRequest(long fromUserId) {
         User fromUser = getUserById(fromUserId);
 
         Set<BlindRequest> usersOfRequestedInfo = blindRequestRepository.findAllByFromUserAndStatus(fromUser, RequestStatus.PENDING);
@@ -147,8 +155,7 @@ public class BlindServiceImpl extends AbstractService implements BlindService {
         return usersOfRequested.stream().map(BlindDateResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    @Override
-    public Set<BlindDateResponse> requestToMe(long toUserId) {
+    private Set<BlindDateResponse> requestToMe(long toUserId) {
         Set<BlindRequest> usersOfRequestedInfo = blindRequestRepository.findAllByToUserAndStatus(getUserById(toUserId), RequestStatus.PENDING);
 
         LinkedHashSet<User> usersOfRequested = new LinkedHashSet<>();


### PR DESCRIPTION
소개팅 요청 조회 로직 구현 완료 하였습니다.

기존에 방식에서 벗어나 내가 한 요청, 나에게 온 요청 둘다 조회할 수 있도록 통합하였습니다.

따라서 만약 13, 16 유저가 나에게 요청을 보냈고 내가 2번 유저에게 요청을 보냈다면,

<img width="625" alt="스크린샷 2023-05-20 오후 5 15 43" src="https://github.com/realSolarDragons/back-end/assets/50222603/8a870832-32cd-44a1-8e65-95ad197a9249">

이런식으로 처리할 수 있게끔 구현하였습니다. 이는 과팅 로직과 동일합니다.
