### PR TITLE
[과팅] 다른 성별의 팀 조회 - 멤버들의 평균나이, 멤버들의 전공 추가

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -22,7 +22,7 @@ public interface GroupController {
      * 다른 성별의 팀 조회
      */
     @GetMapping("/{groupId}/opposite-gender-groups")
-    Response<Page<GroupWithStatusResponse>> getOppositeGenderGroupList(@PathVariable Long groupId, @ParameterObject Pageable pageable);
+    Response<Page<DateableGroupResponse>> getOppositeGenderGroupList(@PathVariable Long groupId, @ParameterObject Pageable pageable);
 
     /**
      * 내가 속한 팀 조회
@@ -58,7 +58,7 @@ public interface GroupController {
      * 팀 기준 - 찜한 목록 조회
      */
     @GetMapping("/{groupId}/likes")
-    Response<Page<LikedDateableGroupResponse>>  getGroupLikeToDateList(@PathVariable Long groupId, @ParameterObject Pageable pageable);
+    Response<Page<DateableGroupResponse>>  getGroupLikeToDateList(@PathVariable Long groupId, @ParameterObject Pageable pageable);
 
     /**
      * 팀 멤버 조회(팀장 포함)

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -32,7 +32,7 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Page<GroupWithStatusResponse>> getOppositeGenderGroupList(Long groupId, Pageable pageable) {
+    public Response<Page<DateableGroupResponse>> getOppositeGenderGroupList(Long groupId, Pageable pageable) {
         Long userId = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 
         return success(groupService.findDateableOppositeGenderGroupList(groupId, userId, pageable));
@@ -78,7 +78,7 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Page<LikedDateableGroupResponse>> getGroupLikeToDateList(Long groupId, Pageable pageable) {
+    public Response<Page<DateableGroupResponse>> getGroupLikeToDateList(Long groupId, Pageable pageable) {
         Long userId = 1L;
 
         return success(groupService.findGroupLikeToDateList(groupId, userId, pageable));

--- a/src/main/java/com/ting/ting/dto/response/DateableGroupResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/DateableGroupResponse.java
@@ -1,5 +1,6 @@
 package com.ting.ting.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ting.ting.domain.Group;
 import com.ting.ting.domain.constant.LikeStatus;
 import com.ting.ting.domain.constant.RequestStatus;
@@ -7,18 +8,25 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
 @Getter
 @Setter
 @AllArgsConstructor
-public class LikedDateableGroupResponse {
+public class DateableGroupResponse {
 
     private GroupWithMemberInfoResponse group;
     private RequestStatus requestStatus;
     private LikeStatus likeStatus;
-    private int likeCount;
+    private Integer likeCount;
 
-    public static LikedDateableGroupResponse from(Group entity, RequestStatus requestStatus, LikeStatus likeStatus, int likeCount) {
-        return new LikedDateableGroupResponse(
+    public static DateableGroupResponse from(Group entity, LikeStatus likeStatus) {
+        return from(entity, null, likeStatus, null);
+    }
+
+    public static DateableGroupResponse from(Group entity, RequestStatus requestStatus, LikeStatus likeStatus, Integer likeCount) {
+        return new DateableGroupResponse(
                 GroupWithMemberInfoResponse.from(entity),
                 requestStatus,
                 likeStatus,

--- a/src/main/java/com/ting/ting/dto/response/GroupResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/GroupResponse.java
@@ -1,5 +1,6 @@
 package com.ting.ting.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ting.ting.domain.Group;
 import com.ting.ting.domain.constant.Gender;
 import com.ting.ting.domain.custom.GroupWithMemberCount;
@@ -8,6 +9,9 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
 @AllArgsConstructor
 @Getter
 public class GroupResponse {

--- a/src/main/java/com/ting/ting/repository/GroupLikeToDateRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupLikeToDateRepository.java
@@ -23,7 +23,4 @@ public interface GroupLikeToDateRepository extends JpaRepository<GroupLikeToDate
 
     @Query(value = "select new com.ting.ting.domain.custom.GroupIdWithLikeCount(entity.toGroup.id, count(*)) from GroupLikeToDate entity where entity.fromGroupMember.group = :fromGroup group by entity.toGroup.id")
     Page<GroupIdWithLikeCount> findAllToGroupIdAndLikeCountByFromGroupMember_Group(@Param("fromGroup") Group fromGroup, Pageable pageable);
-
-    @Query(value = "select entity.toGroup.id from GroupLikeToDate entity where entity.fromGroupMember.group = :group and entity.fromGroupMember.member = :member")
-    List<Long> findAllToGroup_IdByFromGroupMember_GroupAndGroupMember_Member(@Param("group") Group group, @Param("member") User member);
 }

--- a/src/main/java/com/ting/ting/repository/GroupRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupRepository.java
@@ -18,6 +18,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     Optional<Group> findByGroupName(String name);
 
+    Page<Group> findAllByGenderAndIsJoinableAndIsMatchedAndMemberSizeLimit(Gender gender, boolean isJoinable, boolean isMatched, int memberSizeLimit, Pageable pageable);
+
     @EntityGraph(attributePaths = {"groupMembers", "groupMembers.member"})
     List<Group> findAllWithMembersInfoByIdIn(List<Long> groupIds);
 
@@ -25,10 +27,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             "from Group entity left join GroupMember gm on gm.group = entity group by entity.id")
     Page<GroupWithMemberCount> findAllWithMemberCount(Pageable pageable);
 
-    @Query(value = "select new com.ting.ting.domain.custom.GroupWithMemberCount(entity.id, entity.groupName, entity.gender, count(gm), entity.memberSizeLimit, entity.school, entity.isMatched, entity.isJoinable, entity.memo, entity.createdAt) " +
-            "from Group entity left join GroupMember gm on gm.group = entity " +
-            "where entity.gender = :gender and entity.isMatched = :isMatched group by entity.id")
-    Page<GroupWithMemberCount> findAllWithMemberCountByGenderAndIsMatched(@Param("gender") Gender gender, @Param("isMatched") boolean isMatched, Pageable pageable);
 
     @Query(value = "select new com.ting.ting.domain.custom.GroupWithMemberCount(entity.id, entity.groupName, entity.gender, count(gm), entity.memberSizeLimit, entity.school, entity.isMatched, entity.isJoinable, entity.memo, entity.createdAt) " +
             "from Group entity left join GroupMember gm on gm.group = entity " +

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -22,7 +22,7 @@ public interface GroupService {
     /**
      * 다른 성별의 팀 조회
      */
-    Page<GroupWithStatusResponse> findDateableOppositeGenderGroupList(Long groupId, Long userId, Pageable pageable);
+    Page<DateableGroupResponse> findDateableOppositeGenderGroupList(Long groupId, Long userId, Pageable pageable);
 
     /**
      * 내가 속한 팀 조회
@@ -32,7 +32,7 @@ public interface GroupService {
     /**
      * 팀 기준 - 찜한 목록 조회
      */
-    Page<LikedDateableGroupResponse> findGroupLikeToDateList(Long groupId, Long userId, Pageable pageable);
+    Page<DateableGroupResponse> findGroupLikeToDateList(Long groupId, Long userId, Pageable pageable);
 
     /**
      * 팀 멤버 조회

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -39,7 +39,7 @@ insert into `group` (id, group_name, gender, school, member_size_limit, is_match
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (7, '과팅팀7', 'WOMEN', '세종대학교', 4, false, true, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (8, '과팅팀8', 'WOMEN', '홍익대학교', 4, false, true, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (9, '과팅팀9', 'MEN', '가천대학교', 4, false, true, '', now(), now());
-insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (10, '과팅팀10', 'WOMEN', '명지대학교', 4, false, true, '', now(), now());
+insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (10, '과팅팀10', 'WOMEN', '명지대학교', 4, false, false, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (11, '과팅팀11', 'WOMEN', '국민대학교', 4, false, true, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (12, '과팅팀12', 'MEN', '성균관대학교', 4, false, true, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (13, '과팅팀13', 'MEN', '충북대학교', 4, false, true, '', now(), now());
@@ -87,6 +87,9 @@ insert into group_member (group_id, member_id, role, created_at, updated_at) val
 insert into group_member (group_id, member_id, role, created_at, updated_at) values (5, 1, 'MEMBER', now(), now());
 insert into group_member (group_id, member_id, role, created_at, updated_at) values (4, 21, 'MEMBER', now(), now());
 insert into group_member (group_id, member_id, role, created_at, updated_at) values (17, 29, 'MEMBER', now(), now());
+insert into group_member (group_id, member_id, role, created_at, updated_at) values (10, 29, 'MEMBER', now(), now());
+insert into group_member (group_id, member_id, role, created_at, updated_at) values (10, 28, 'MEMBER', now(), now());
+insert into group_member (group_id, member_id, role, created_at, updated_at) values (10, 27, 'MEMBER', now(), now());
 
 insert into group_member_request (group_id, user_id, created_at, updated_at) values (1, 5, now(), now());
 insert into group_member_request (group_id, user_id, created_at, updated_at) values (1, 4, now(), now());

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -27,7 +27,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -94,17 +93,29 @@ class GroupServiceTest {
         Long groupId = 1L;
         Pageable pageable = Pageable.ofSize(20);
 
-        Group group = GroupFixture.createGroupById(groupId);
-        List<Long> likedGroupIds = Arrays.asList(1L, 2L, 3L);
+        Group myGroup = GroupFixture.createGroupById(groupId);
+        Group oppositeGenderGroup = GroupFixture.createGroupById(groupId + 1);
+        User oppositeGenderGroupMember = UserFixture.createUserById(user.getId() + 1);
+        GroupMember oppositeGenderGroupMemberRecord = GroupMember.of(oppositeGenderGroup, oppositeGenderGroupMember, MemberRole.LEADER);
+        ReflectionTestUtils.setField(oppositeGenderGroup, "groupMembers", Set.of(oppositeGenderGroupMemberRecord));
 
-        given(groupRepository.findById(any())).willReturn(Optional.of(group));
-        given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
-        given(groupMemberRepository.existsByGroupAndMember(any(), any())).willReturn(true);
-        given(groupRepository.findAllWithMemberCountByGenderAndIsMatched(any(), anyBoolean(), any())).willReturn(Page.empty());
-        given(groupLikeToDateRepository.findAllToGroup_IdByFromGroupMember_GroupAndGroupMember_Member(any(), any())).willReturn(likedGroupIds);
+        given(groupRepository.findById(any())).willReturn(Optional.of(myGroup));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(groupMemberRepository.findByGroupAndMember(any(), any())).willReturn(Optional.of(mock(GroupMember.class)));
+        given(groupRepository.findAllByGenderAndIsJoinableAndIsMatchedAndMemberSizeLimit(myGroup.getGender().getOpposite(), false, false, myGroup.getMemberSizeLimit(), pageable))
+                .willReturn(new PageImpl<>(List.of(oppositeGenderGroup)));
+        given(groupRepository.findAllWithMembersInfoByIdIn(List.of(oppositeGenderGroup.getId()))).willReturn(List.of(oppositeGenderGroup));
+        given(groupLikeToDateRepository.findAllByFromGroupMember(any())).willReturn(List.of());
 
-        //When & Then
-        assertThat(groupService.findDateableOppositeGenderGroupList(groupId, user.getId(), pageable)).isEmpty();
+        //When
+        Page<DateableGroupResponse> created = groupService.findDateableOppositeGenderGroupList(groupId, user.getId(), pageable);
+
+        //Then
+        List<DateableGroupResponse> createdList = created.getContent().stream().collect(Collectors.toList());
+        assertThat(createdList).hasSize(1);
+        assertThat(createdList.get(0)).hasNoNullFieldsOrPropertiesExcept("requestStatus", "likeCount");
+        assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("likeStatus", LikeStatus.NOT_LIKED);
+        assertThat(createdList.get(0).getGroup().getMajorsOfMembers()).hasSize(1);
     }
 
     @DisplayName("내가 속한 팀 조회 기능 테스트")
@@ -160,10 +171,10 @@ class GroupServiceTest {
         given(groupLikeToDateRepository.findAllByFromGroupMember(fromGroupMemberRecord)).willReturn(List.of());
 
         //When
-        Page<LikedDateableGroupResponse> created = groupService.findGroupLikeToDateList(groupId, user.getId(), pageable);
+        Page<DateableGroupResponse> created = groupService.findGroupLikeToDateList(groupId, user.getId(), pageable);
 
         //Then
-        List<LikedDateableGroupResponse> createdList = created.getContent().stream().collect(Collectors.toList());
+        List<DateableGroupResponse> createdList = created.getContent().stream().collect(Collectors.toList());
         assertThat(createdList).hasSize(1);
         assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("requestStatus", RequestStatus.EMPTY);
         assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("likeStatus", LikeStatus.NOT_LIKED);


### PR DESCRIPTION
* [상대팀 조회시에 멤버 전공, 평균나이 반환하도록 비즈니스 로직 수정](https://github.com/realSolarDragons/back-end/commit/de7acda0029a7c4a15eca22f2e9c2460c8b89f25)
    * response dto 에 `JsonInclude(NON_NULL)` 어노테이션을 추가해서 null 값은 프론트에 반환하지 않도록 수정했습니다.
    * https://github.com/realSolarDragons/back-end/pull/103 에서는 상대팀의 현재 멤버수도 포함하도록 했지만 생각해보면 `isJoinable` 이 false 이면memberSizeLImit 이 현재 멤버수를 나타내기 때문에 상대팀의 현재 멤버수는 포함하지 않도록 수정했습니다.


### 결과
<img width="50%" alt="image" src="https://github.com/realSolarDragons/back-end/assets/83967710/b9daab8d-6009-4bc0-b641-5996c2d2cea5">



This closes #121 