### PR TITLE
[과팅] 유저 기준 - 찜한 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/ting/ting/configuration/AppConfig.java
+++ b/src/main/java/com/ting/ting/configuration/AppConfig.java
@@ -29,7 +29,7 @@ public class AppConfig {
 
     @Bean
     public GroupLikeService groupLikeService() {
-        return new GroupLikeServiceImpl(userRepository, groupRepository, groupMemberRepository, groupDateRequestRepository, groupLikeToJoinRepository, groupLikeToDateRepository);
+        return new GroupLikeServiceImpl(userRepository, groupRepository, groupMemberRepository, groupMemberRequestRepository, groupDateRequestRepository, groupLikeToJoinRepository, groupLikeToDateRepository);
     }
 
     @Bean

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -16,7 +16,7 @@ public interface GroupController {
      * 같은 성별 이면서 내가 속한 팀이 아닌 팀 조회
      */
     @GetMapping
-    Response<Page<GroupWithStatusResponse>> getJoinableSameGenderGroupList(@ParameterObject Pageable pageable);
+    Response<Page<JoinableGroupResponse>> getJoinableSameGenderGroupList(@ParameterObject Pageable pageable);
 
     /**
      * 다른 성별의 팀 조회
@@ -55,10 +55,16 @@ public interface GroupController {
     Response<Void> deleteOppositeGenderGroupLike(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
 
     /**
-     * 팀 기준 - 찜한 목록 조회
+     * 팀 기준 - 찜한 목록 조회(과팅 요청을 위한)
      */
     @GetMapping("/{groupId}/likes")
-    Response<Page<DateableGroupResponse>>  getGroupLikeToDateList(@PathVariable Long groupId, @ParameterObject Pageable pageable);
+    Response<Page<DateableGroupResponse>> getGroupLikeToDateList(@PathVariable Long groupId, @ParameterObject Pageable pageable);
+
+    /**
+     * 유저 기준 - 찜한 같은 성별의 팀 목록 조회(팀 가입을 위한)
+     */
+    @GetMapping("/likes")
+    Response<Page<JoinableGroupResponse>> getGroupLikeToJoinList(@ParameterObject Pageable pageable);
 
     /**
      * 팀 멤버 조회(팀장 포함)

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -25,7 +25,7 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Page<GroupWithStatusResponse>> getJoinableSameGenderGroupList(Pageable pageable) {
+    public Response<Page<JoinableGroupResponse>> getJoinableSameGenderGroupList(Pageable pageable) {
         Long userId = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 
         return success(groupService.findJoinableSameGenderGroupList(userId, pageable));
@@ -82,6 +82,13 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
         Long userId = 1L;
 
         return success(groupLikeService.findGroupLikeToDateList(groupId, userId, pageable));
+    }
+
+    @Override
+    public Response<Page<JoinableGroupResponse>> getGroupLikeToJoinList(Pageable pageable) {
+        Long userId = 1L;
+
+        return success(groupLikeService.findGroupLikeToJoinList(userId, pageable));
     }
 
     @Override

--- a/src/main/java/com/ting/ting/dto/response/JoinableGroupResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/JoinableGroupResponse.java
@@ -5,20 +5,19 @@ import com.ting.ting.domain.constant.RequestStatus;
 import com.ting.ting.domain.custom.GroupWithMemberCount;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
-public class GroupWithStatusResponse {
+public class JoinableGroupResponse {
 
     private GroupResponse group;
     private RequestStatus requestStatus;
     private LikeStatus likeStatus;
 
-    public static GroupWithStatusResponse from(GroupWithMemberCount groupWithMemberCount, RequestStatus requestStatus, LikeStatus likeStatus) {
-        return new GroupWithStatusResponse(
+    public static JoinableGroupResponse from(GroupWithMemberCount groupWithMemberCount, RequestStatus requestStatus, LikeStatus likeStatus) {
+        return new JoinableGroupResponse(
                 GroupResponse.from(groupWithMemberCount),
                 requestStatus,
                 likeStatus

--- a/src/main/java/com/ting/ting/repository/GroupLikeToJoinRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupLikeToJoinRepository.java
@@ -3,9 +3,9 @@ package com.ting.ting.repository;
 import com.ting.ting.domain.Group;
 import com.ting.ting.domain.GroupLikeToJoin;
 import com.ting.ting.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,6 +15,7 @@ public interface GroupLikeToJoinRepository extends JpaRepository<GroupLikeToJoin
 
     void deleteByFromUser_IdAndToGroup_Id(Long userId, Long groupId);
 
-    @Query(value = "select entity.toGroup from GroupLikeToJoin entity where entity.fromUser = :fromUser")
-    List<Group> findAllToGroupByFromUser(@Param("fromUser") User fromUser);
+    Page<GroupLikeToJoin> findAllByFromUser(User fromUser, Pageable pageable);
+
+    List<GroupLikeToJoin> findAllByFromUser(User fromUser);
 }

--- a/src/main/java/com/ting/ting/repository/GroupMemberRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupMemberRequestRepository.java
@@ -12,8 +12,7 @@ import java.util.Optional;
 
 public interface GroupMemberRequestRepository extends JpaRepository<GroupMemberRequest, Long> {
 
-    @Query(value = "select entity.group from GroupMemberRequest entity where entity.user = :user")
-    List<Group> findAllGroupByUser(@Param("user") User user);
+    List<GroupMemberRequest> findAllByUser(User user);
 
     Optional<GroupMemberRequest> findByGroupAndUser(Group group, User user);
 

--- a/src/main/java/com/ting/ting/repository/GroupRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupRepository.java
@@ -24,6 +24,10 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findAllWithMembersInfoByIdIn(List<Long> groupIds);
 
     @Query(value = "select new com.ting.ting.domain.custom.GroupWithMemberCount(entity.id, entity.groupName, entity.gender, count(gm), entity.memberSizeLimit, entity.school, entity.isMatched, entity.isJoinable, entity.memo, entity.createdAt) " +
+            "from Group entity left join GroupMember gm on gm.group = entity where entity.id in :groupIds group by entity.id")
+    List<GroupWithMemberCount> findAllWithMemberCountByIdIn(@Param("groupIds") List<Long> groupIds);
+
+    @Query(value = "select new com.ting.ting.domain.custom.GroupWithMemberCount(entity.id, entity.groupName, entity.gender, count(gm), entity.memberSizeLimit, entity.school, entity.isMatched, entity.isJoinable, entity.memo, entity.createdAt) " +
             "from Group entity left join GroupMember gm on gm.group = entity group by entity.id")
     Page<GroupWithMemberCount> findAllWithMemberCount(Pageable pageable);
 

--- a/src/main/java/com/ting/ting/service/GroupLikeService.java
+++ b/src/main/java/com/ting/ting/service/GroupLikeService.java
@@ -1,6 +1,7 @@
 package com.ting.ting.service;
 
 import com.ting.ting.dto.response.DateableGroupResponse;
+import com.ting.ting.dto.response.JoinableGroupResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,6 +11,11 @@ public interface GroupLikeService {
      * 팀 기준 - 찜한 목록 조회
      */
     Page<DateableGroupResponse> findGroupLikeToDateList(Long groupId, Long userId, Pageable pageable);
+
+    /**
+     * 유저 기준 - 찜한 같은 성별의 팀 조회
+     */
+    Page<JoinableGroupResponse> findGroupLikeToJoinList(Long userId, Pageable pageable);
 
     /**
      * 같은 성별의 팀 찜하기

--- a/src/main/java/com/ting/ting/service/GroupLikeServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupLikeServiceImpl.java
@@ -103,14 +103,14 @@ public class GroupLikeServiceImpl extends AbstractService implements GroupLikeSe
                 .map(likedGroup -> {
                     JoinableGroupResponse response = JoinableGroupResponse.from(likedGroup, RequestStatus.EMPTY, LikeStatus.LIKED);
 
-                    if (!likedGroup.isJoinable()) {
-                        response.setRequestStatus(null);
+                    if (likedGroup.isJoinable() == false) {
+                        response.setRequestStatus(RequestStatus.DISABLED);
                     } else if (pendingJoinRequestGroupIds.contains(likedGroup.getId())) {
                         response.setRequestStatus(RequestStatus.PENDING);
                     }
 
                     return response;
-                }).collect(Collectors.toList());
+        }).collect(Collectors.toList());
 
         return new PageImpl<>(likedJoinableGroupResponses, pageable, groupLikesToJoin.getTotalElements());
     }

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -17,7 +17,7 @@ public interface GroupService {
     /**
      * 같은 성별 이면서 내가 속한 팀이 아닌 팀 조회
      */
-    Page<GroupWithStatusResponse> findJoinableSameGenderGroupList(Long userId, Pageable pageable);
+    Page<JoinableGroupResponse> findJoinableSameGenderGroupList(Long userId, Pageable pageable);
 
     /**
      * 다른 성별의 팀 조회

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -55,16 +55,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public Page<GroupWithStatusResponse> findJoinableSameGenderGroupList(Long userId, Pageable pageable) {
+    public Page<JoinableGroupResponse> findJoinableSameGenderGroupList(Long userId, Pageable pageable) {
         User user = loadUserByUserId(userId);
 
         Page<GroupWithMemberCount> joinableSameGenderGroups = groupRepository.findAllJoinableGroupWithMemberCountByGenderAndIsJoinableAndNotGroupMembers_Member(user.getGender(), true, user, pageable);
-        Set<Long> myPendingJoinGroupIds = groupMemberRequestRepository.findAllGroupByUser(user).stream().map(Group::getId).collect(Collectors.toUnmodifiableSet());
-        Set<Long> myLikeGroupIds = groupLikeToJoinRepository.findAllToGroupByFromUser(user).stream().map(Group::getId).collect(Collectors.toUnmodifiableSet());
+        Set<Long> myPendingJoinGroupIds = groupMemberRequestRepository.findAllByUser(user).stream().map(GroupMemberRequest::getGroup).map(Group::getId).collect(Collectors.toUnmodifiableSet());
+        Set<Long> myLikeGroupIds = groupLikeToJoinRepository.findAllByFromUser(user).stream().map(GroupLikeToJoin::getToGroup).map(Group::getId).collect(Collectors.toUnmodifiableSet());
 
-        List<GroupWithStatusResponse> groupWithStatusResponses = joinableSameGenderGroups.stream()
+        List<JoinableGroupResponse> joinableGroupRespons = joinableSameGenderGroups.stream()
                 .map(joinableSameGenderGroup -> {
-                    GroupWithStatusResponse response = GroupWithStatusResponse.from(joinableSameGenderGroup, RequestStatus.EMPTY, null);
+                    JoinableGroupResponse response = JoinableGroupResponse.from(joinableSameGenderGroup, RequestStatus.EMPTY, null);
 
                     if (myPendingJoinGroupIds.contains(joinableSameGenderGroup.getId())) {
                         response.setRequestStatus(RequestStatus.PENDING);
@@ -79,7 +79,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                     return response;
         }).collect(Collectors.toList());
 
-        return new PageImpl<>(groupWithStatusResponses, pageable, joinableSameGenderGroups.getTotalElements());
+        return new PageImpl<>(joinableGroupRespons, pageable, joinableSameGenderGroups.getTotalElements());
     }
 
     @Override

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -47,11 +47,12 @@ insert into `group` (id, group_name, gender, school, member_size_limit, is_match
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (15, '과팅팀15', 'WOMEN', '아주대학교', 4, false, true, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (16, '과팅팀16', 'MEN', '숭실대학교', 4, false, true, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (17, '과팅팀17', 'WOMEN', '이화여자대학교', 4, false, true, '', now(), now());
-insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (18, '과팅팀18', 'MEN', '한양대학교', 4, false, true, '', now(), now());
+insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (18, '과팅팀18', 'MEN', '한양대학교', 4, false, false, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (19, '과팅팀19', 'MEN', '서울시립대학교', 4, false, true, '', now(), now());
 insert into `group` (id, group_name, gender, school, member_size_limit, is_matched, is_joinable, memo, created_at, updated_at) values (20, '과팅팀20', 'WOMEN', '서울예술대학교', 4, false, true, '', now(), now());
 
 insert into group_like_to_join(from_user_id, to_group_id, created_at, updated_at) values (1, 16, now(), now());
+insert into group_like_to_join(from_user_id, to_group_id, created_at, updated_at) values (1, 18, now(), now());
 
 insert into group_date_request(id, from_id, to_id, created_at, updated_at) values (1, 2, 1, now(), now());
 insert into group_date_request(id, from_id, to_id, created_at, updated_at) values (2, 6, 1, now(), now());
@@ -90,6 +91,9 @@ insert into group_member (group_id, member_id, role, created_at, updated_at) val
 insert into group_member (group_id, member_id, role, created_at, updated_at) values (10, 29, 'MEMBER', now(), now());
 insert into group_member (group_id, member_id, role, created_at, updated_at) values (10, 28, 'MEMBER', now(), now());
 insert into group_member (group_id, member_id, role, created_at, updated_at) values (10, 27, 'MEMBER', now(), now());
+insert into group_member (group_id, member_id, role, created_at, updated_at) values (18, 21, 'MEMBER', now(), now());
+insert into group_member (group_id, member_id, role, created_at, updated_at) values (18, 22, 'MEMBER', now(), now());
+insert into group_member (group_id, member_id, role, created_at, updated_at) values (18, 23, 'MEMBER', now(), now());
 
 insert into group_member_request (group_id, user_id, created_at, updated_at) values (1, 5, now(), now());
 insert into group_member_request (group_id, user_id, created_at, updated_at) values (1, 4, now(), now());

--- a/src/test/java/com/ting/ting/service/GroupServiceLikeTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceLikeTest.java
@@ -122,7 +122,7 @@ class GroupLikeServiceTest {
         assertThat(createdList).hasSize(2);
         assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("requestStatus", RequestStatus.PENDING);
         assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("likeStatus", LikeStatus.LIKED);
-        assertThat(createdList.get(1)).hasFieldOrPropertyWithValue("requestStatus", null);
+        assertThat(createdList.get(1)).hasFieldOrPropertyWithValue("requestStatus", RequestStatus.DISABLED);
         assertThat(createdList.get(1)).hasFieldOrPropertyWithValue("likeStatus", LikeStatus.LIKED);
     }
 

--- a/src/test/java/com/ting/ting/service/GroupServiceLikeTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceLikeTest.java
@@ -1,15 +1,14 @@
 package com.ting.ting.service;
 
-import com.ting.ting.domain.Group;
-import com.ting.ting.domain.GroupLikeToDate;
-import com.ting.ting.domain.GroupMember;
-import com.ting.ting.domain.User;
+import com.ting.ting.domain.*;
 import com.ting.ting.domain.constant.Gender;
 import com.ting.ting.domain.constant.LikeStatus;
 import com.ting.ting.domain.constant.MemberRole;
 import com.ting.ting.domain.constant.RequestStatus;
 import com.ting.ting.domain.custom.GroupIdWithLikeCount;
+import com.ting.ting.domain.custom.GroupWithMemberCount;
 import com.ting.ting.dto.response.DateableGroupResponse;
+import com.ting.ting.dto.response.JoinableGroupResponse;
 import com.ting.ting.fixture.GroupFixture;
 import com.ting.ting.fixture.UserFixture;
 import com.ting.ting.repository.*;
@@ -47,6 +46,7 @@ class GroupLikeServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private GroupRepository groupRepository;
     @Mock private GroupMemberRepository groupMemberRepository;
+    @Mock private GroupMemberRequestRepository groupMemberRequestRepository;
     @Mock private GroupDateRequestRepository groupDateRequestRepository;
     @Mock private GroupLikeToJoinRepository groupLikeToJoinRepository;
     @Mock private GroupLikeToDateRepository groupLikeToDateRepository;
@@ -94,6 +94,36 @@ class GroupLikeServiceTest {
         assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("likeCount", 2);
         assertThat(createdList.get(0).getGroup().getMajorsOfMembers()).hasSize(1);
         assertThat(createdList.get(0).getGroup().getAverageAgeOfMembers()).isSameAs(10);
+    }
+
+    @DisplayName("유저 기준 - 같은 성별 팀 찜한 목록 조회 기능 테스트")
+    @Test
+    void Given_Nothing_WHen_FindGroupLikeToJoinList_Then_ReturnsJoinableGroupResponse() {
+        //Given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Group toGroup1 = GroupFixture.createGroupById(1L);
+        Group toGroup2 = GroupFixture.createGroupById(2L);
+        GroupLikeToJoin groupLikeToJoin1 = GroupLikeToJoin.of(user, toGroup1);
+        GroupLikeToJoin groupLikeToJoin2 = GroupLikeToJoin.of(user, toGroup2);
+        GroupWithMemberCount joinableGroupWithMemberCount = new GroupWithMemberCount(toGroup1.getId(), toGroup1.getGroupName(), toGroup1.getGender(), 2L, toGroup1.getMemberSizeLimit(), toGroup1.getSchool(), toGroup1.isMatched(), true, toGroup1.getMemo(), toGroup1.getCreatedAt());
+        GroupWithMemberCount notJoinableGroupWithMemberCount = new GroupWithMemberCount(toGroup2.getId(), toGroup2.getGroupName(), toGroup2.getGender(), 2L, toGroup2.getMemberSizeLimit(), toGroup2.getSchool(), toGroup2.isMatched(), false, toGroup2.getMemo(), toGroup2.getCreatedAt());
+
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(groupLikeToJoinRepository.findAllByFromUser(user, pageable)).willReturn(new PageImpl<>(List.of(groupLikeToJoin1, groupLikeToJoin2)));
+        given(groupRepository.findAllWithMemberCountByIdIn(any())).willReturn(List.of(joinableGroupWithMemberCount, notJoinableGroupWithMemberCount));
+        given(groupMemberRequestRepository.findAllByUser(user)).willReturn(List.of(GroupMemberRequest.of(toGroup1, user)));
+
+        //When
+        Page<JoinableGroupResponse> created = groupLikeService.findGroupLikeToJoinList(user.getId(), pageable);
+
+        //Then
+        List<JoinableGroupResponse> createdList = created.getContent().stream().collect(Collectors.toList());
+        assertThat(createdList).hasSize(2);
+        assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("requestStatus", RequestStatus.PENDING);
+        assertThat(createdList.get(0)).hasFieldOrPropertyWithValue("likeStatus", LikeStatus.LIKED);
+        assertThat(createdList.get(1)).hasFieldOrPropertyWithValue("requestStatus", null);
+        assertThat(createdList.get(1)).hasFieldOrPropertyWithValue("likeStatus", LikeStatus.LIKED);
     }
 
     @DisplayName("같은 성별의 팀 찜하기 기능 테스트")

--- a/src/test/java/com/ting/ting/service/GroupServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupServiceTest.java
@@ -75,8 +75,8 @@ class GroupServiceTest {
 
         given(userRepository.findById(any())).willReturn(Optional.of(user));
         given(groupRepository.findAllJoinableGroupWithMemberCountByGenderAndIsJoinableAndNotGroupMembers_Member(any(), anyBoolean(), any(), any())).willReturn(Page.empty());
-        given(groupMemberRequestRepository.findAllGroupByUser(user)).willReturn(List.of());
-        given(groupLikeToJoinRepository.findAllToGroupByFromUser(user)).willReturn(List.of());
+        given(groupMemberRequestRepository.findAllByUser(user)).willReturn(List.of());
+        given(groupLikeToJoinRepository.findAllByFromUser(user)).willReturn(List.of());
 
         //When
         assertThat(groupService.findJoinableSameGenderGroupList(user.getId(), pageable)).isEmpty();


### PR DESCRIPTION
로직은 다른 성별의 찜 목록 조회 비즈니스 로직과 비슷합니다

### 결과
<img src="https://github.com/realSolarDragons/back-end/assets/83967710/1e217532-e664-4314-a847-f1afcfa8c462" width="60%"/>

### api가 사용되는 페이지
<img src="https://github.com/realSolarDragons/back-end/assets/83967710/70395176-7456-41ec-8b85-f6bc6e415892" width="40%"/>


This closes #119 
