### PR TITLE
[과팅] 과팅 가입 요청 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/ting/ting/configuration/AppConfig.java
+++ b/src/main/java/com/ting/ting/configuration/AppConfig.java
@@ -29,7 +29,7 @@ public class AppConfig {
 
     @Bean
     public GroupMemberService groupMemberService() {
-        return new GroupMemberServiceImpl(userRepository, groupRepository, groupMemberRepository, groupMemberRequestRepository);
+        return new GroupMemberServiceImpl(userRepository, groupRepository, groupLikeToJoinRepository, groupMemberRepository, groupMemberRequestRepository);
     }
 
     @Bean

--- a/src/main/java/com/ting/ting/configuration/AppConfig.java
+++ b/src/main/java/com/ting/ting/configuration/AppConfig.java
@@ -28,6 +28,11 @@ public class AppConfig {
     }
 
     @Bean
+    public GroupMemberService groupMemberService() {
+        return new GroupMemberServiceImpl(userRepository, groupRepository, groupMemberRepository, groupMemberRequestRepository);
+    }
+
+    @Bean
     public GroupLikeService groupLikeService() {
         return new GroupLikeServiceImpl(userRepository, groupRepository, groupMemberRepository, groupMemberRequestRepository, groupDateRequestRepository, groupLikeToJoinRepository, groupLikeToDateRepository);
     }

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -111,13 +111,13 @@ public interface GroupController {
     /**
      * 같은 성별인 팀에 요청
      */
-    @PostMapping("/request/{groupId}")
+    @PostMapping("/requests/{groupId}")
     Response<Void> sendJoinRequest(@PathVariable Long groupId);
 
     /**
      * 같은 성별인 팀에 했던 요청을 취소
      */
-    @DeleteMapping("/request/{groupId}")
+    @DeleteMapping("/requests/{groupId}")
     Response<Void> deleteJoinRequest(@PathVariable Long groupId);
 
     /**

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -67,16 +67,46 @@ public interface GroupController {
     Response<Page<JoinableGroupResponse>> getGroupLikeToJoinList(@ParameterObject Pageable pageable);
 
     /**
-     * 팀 멤버 조회(팀장 포함)
-     */
-    @GetMapping("/{groupId}/members")
-    Response<Set<GroupMemberResponse>> getGroupMemberList(@PathVariable Long groupId);
-
-    /**
      * 그룹 생성
      */
     @PostMapping
     Response<GroupResponse> createGroup(@RequestBody GroupRequest request);
+
+    /**
+     * 팀장 - 과팅 요청 조회(받은 요청, 한 요청 모두)
+     */
+    @GetMapping("/{groupId}/dates/requests")
+    Response<GroupDateRequestWithFromAndToResponse> getGroupDateRequest(@PathVariable Long groupId);
+
+    /**
+     * 팀장 - 과팅 요청
+     */
+    @PostMapping("/{fromGroupId}/dates/requests/{toGroupId}")
+    Response<GroupDateRequestResponse> saveGroupDateRequest(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
+
+    /**
+     * 팀장 - 과팅 요청 취소
+     */
+    @DeleteMapping("/{fromGroupId}/dates/requests/{toGroupId}")
+    Response<Void> deleteGroupDateRequest(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
+
+    /**
+     * 팀장 - 과팅 요청 수락
+     */
+    @PostMapping("/dates/requests/{groupDateRequestId}")
+    Response<GroupDateResponse> acceptGroupDateRequest(@PathVariable Long groupDateRequestId);
+
+    /**
+     * 팀장 - 과팅 요청 거절
+     */
+    @DeleteMapping("/dates/requests/{groupDateRequestId}")
+    Response<Void> rejectGroupDateRequest(@PathVariable Long groupDateRequestId);
+
+    /**
+     * 팀 멤버 조회(팀장 포함)
+     */
+    @GetMapping("/{groupId}/members")
+    Response<Set<GroupMemberResponse>> getGroupMemberList(@PathVariable Long groupId);
 
     /**
      * 같은 성별인 팀에 요청
@@ -119,34 +149,4 @@ public interface GroupController {
      */
     @DeleteMapping("/members/requests/{groupMemberRequestId}")
     Response<Void> rejectJoinRequestToMyGroup(@PathVariable Long groupMemberRequestId);
-
-    /**
-     * 팀장 - 과팅 요청 조회(받은 요청, 한 요청 모두)
-     */
-    @GetMapping("/{groupId}/dates/requests")
-    Response<GroupDateRequestWithFromAndToResponse> getGroupDateRequest(@PathVariable Long groupId);
-
-    /**
-     * 팀장 - 과팅 요청
-     */
-    @PostMapping("/{fromGroupId}/dates/requests/{toGroupId}")
-    Response<GroupDateRequestResponse> saveGroupDateRequest(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
-
-    /**
-     * 팀장 - 과팅 요청 취소
-     */
-    @DeleteMapping("/{fromGroupId}/dates/requests/{toGroupId}")
-    Response<Void> deleteGroupDateRequest(@PathVariable Long fromGroupId, @PathVariable Long toGroupId);
-
-    /**
-     * 팀장 - 과팅 요청 수락
-     */
-    @PostMapping("/dates/requests/{groupDateRequestId}")
-    Response<GroupDateResponse> acceptGroupDateRequest(@PathVariable Long groupDateRequestId);
-
-    /**
-     * 팀장 - 과팅 요청 거절
-     */
-    @DeleteMapping("/dates/requests/{groupDateRequestId}")
-    Response<Void> rejectGroupDateRequest(@PathVariable Long groupDateRequestId);
 }

--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -109,7 +109,13 @@ public interface GroupController {
     Response<Set<GroupMemberResponse>> getGroupMemberList(@PathVariable Long groupId);
 
     /**
-     * 같은 성별인 팀에 요청
+     * 과팅 가입 요청 조회
+     */
+    @GetMapping("/requests")
+    Response<Page<JoinableGroupResponse>> getUserJoinRequestList(@ParameterObject Pageable pageable);
+
+    /**
+     * 같은 성별인 팀에 가입 요청
      */
     @PostMapping("/requests/{groupId}")
     Response<Void> sendJoinRequest(@PathVariable Long groupId);

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -143,6 +143,13 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
+    public Response<Page<JoinableGroupResponse>> getUserJoinRequestList(Pageable pageable) {
+        Long userId = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        return success(groupMemberService.findUserJoinRequestList(userId, pageable));
+    }
+
+    @Override
     public Response<Void> sendJoinRequest(Long groupId) {
         Long userId = groupId + 1;  // userId를 임의로 설정 TODO: user 구현 후 수정
 

--- a/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
+++ b/src/main/java/com/ting/ting/controller/GroupControllerImpl.java
@@ -4,6 +4,7 @@ import com.ting.ting.dto.request.GroupRequest;
 import com.ting.ting.dto.response.*;
 import com.ting.ting.exception.ServiceType;
 import com.ting.ting.service.GroupLikeService;
+import com.ting.ting.service.GroupMemberService;
 import com.ting.ting.service.GroupService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,11 +17,13 @@ import java.util.Set;
 public class GroupControllerImpl extends AbstractController implements GroupController {
 
     private final GroupService groupService;
+    private final GroupMemberService groupMemberService;
     private final GroupLikeService groupLikeService;
 
-    public GroupControllerImpl(GroupService groupService, GroupLikeService groupLikeService) {
+    public GroupControllerImpl(GroupService groupService, GroupMemberService groupMemberService, GroupLikeService groupLikeService) {
         super(ServiceType.GROUP_MEETING);
         this.groupService = groupService;
+        this.groupMemberService = groupMemberService;
         this.groupLikeService = groupLikeService;
     }
 
@@ -92,67 +95,9 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
     }
 
     @Override
-    public Response<Set<GroupMemberResponse>> getGroupMemberList(Long groupId) {
-        return success(groupService.findGroupMemberList(groupId));
-    }
-
-    @Override
     public Response<GroupResponse> createGroup(GroupRequest request) {
         Long userId = 9L;  // userId를 임의로 설정 TODO: user 구현 후 수정
         return success(groupService.saveGroup(userId, request));
-    }
-
-    @Override
-    public Response<Void> sendJoinRequest(Long groupId) {
-        Long userId = groupId + 1;  // userId를 임의로 설정 TODO: user 구현 후 수정
-
-        groupService.saveJoinRequest(groupId, userId);
-        return success();
-    }
-
-    @Override
-    public Response<Void> deleteJoinRequest(Long groupId) {
-        Long userId = groupId + 1;  // userId를 임의로 설정 TODO: user 구현 후 수정
-
-        groupService.deleteJoinRequest(groupId, userId);
-        return success();
-    }
-    
-    @Override
-    public Response<Void> deleteGroupMember(Long groupId) {
-        Long userId = 1L;
-
-        groupService.deleteGroupMember(groupId, userId);
-        return success();
-    }
-
-    @Override
-    public Response<Set<GroupMemberResponse>> changeGroupLeader(Long groupId, Long userIdOfNewLeader) {
-        Long userIdOfLeader = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
-
-        return success(groupService.changeGroupLeader(groupId, userIdOfLeader, userIdOfNewLeader));
-    }
-
-    @Override
-    public Response<Set<GroupMemberRequestResponse>> getMemberRequestToJoinMyGroup(Long groupId) {
-        Long userIdOfLeader = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
-
-        return success(groupService.findMemberJoinRequest(groupId, userIdOfLeader));
-    }
-
-    @Override
-    public Response<GroupMemberResponse> acceptJoinRequestToMyGroup(Long groupMemberRequestId) {
-        Long userIdOfLeader = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
-
-        return success(groupService.acceptMemberJoinRequest(userIdOfLeader, groupMemberRequestId));
-    }
-
-    @Override
-    public Response<Void> rejectJoinRequestToMyGroup(Long groupMemberRequestId) {
-        Long userIdOfLeader = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
-
-        groupService.rejectMemberJoinRequest(userIdOfLeader, groupMemberRequestId);
-        return success();
     }
 
     @Override
@@ -189,6 +134,64 @@ public class GroupControllerImpl extends AbstractController implements GroupCont
         Long userIdOfLeader = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
 
         groupService.rejectGroupDateRequest(userIdOfLeader, groupDateRequestId);
+        return success();
+    }
+
+    @Override
+    public Response<Set<GroupMemberResponse>> getGroupMemberList(Long groupId) {
+        return success(groupMemberService.findGroupMemberList(groupId));
+    }
+
+    @Override
+    public Response<Void> sendJoinRequest(Long groupId) {
+        Long userId = groupId + 1;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        groupMemberService.saveJoinRequest(groupId, userId);
+        return success();
+    }
+
+    @Override
+    public Response<Void> deleteJoinRequest(Long groupId) {
+        Long userId = groupId + 1;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        groupMemberService.deleteJoinRequest(groupId, userId);
+        return success();
+    }
+
+    @Override
+    public Response<Void> deleteGroupMember(Long groupId) {
+        Long userId = 1L;
+
+        groupMemberService.deleteGroupMember(groupId, userId);
+        return success();
+    }
+
+    @Override
+    public Response<Set<GroupMemberResponse>> changeGroupLeader(Long groupId, Long userIdOfNewLeader) {
+        Long userIdOfLeader = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        return success(groupMemberService.changeGroupLeader(groupId, userIdOfLeader, userIdOfNewLeader));
+    }
+
+    @Override
+    public Response<Set<GroupMemberRequestResponse>> getMemberRequestToJoinMyGroup(Long groupId) {
+        Long userIdOfLeader = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        return success(groupMemberService.findMemberJoinRequest(groupId, userIdOfLeader));
+    }
+
+    @Override
+    public Response<GroupMemberResponse> acceptJoinRequestToMyGroup(Long groupMemberRequestId) {
+        Long userIdOfLeader = 1L;  // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        return success(groupMemberService.acceptMemberJoinRequest(userIdOfLeader, groupMemberRequestId));
+    }
+
+    @Override
+    public Response<Void> rejectJoinRequestToMyGroup(Long groupMemberRequestId) {
+        Long userIdOfLeader = 1L; // userId를 임의로 설정 TODO: user 구현 후 수정
+
+        groupMemberService.rejectMemberJoinRequest(userIdOfLeader, groupMemberRequestId);
         return success();
     }
 }

--- a/src/main/java/com/ting/ting/repository/GroupMemberRequestRepository.java
+++ b/src/main/java/com/ting/ting/repository/GroupMemberRequestRepository.java
@@ -3,6 +3,8 @@ package com.ting.ting.repository;
 import com.ting.ting.domain.Group;
 import com.ting.ting.domain.GroupMemberRequest;
 import com.ting.ting.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,8 @@ import java.util.Optional;
 public interface GroupMemberRequestRepository extends JpaRepository<GroupMemberRequest, Long> {
 
     List<GroupMemberRequest> findAllByUser(User user);
+
+    Page<GroupMemberRequest> findAllByUser(User user, Pageable pageable);
 
     Optional<GroupMemberRequest> findByGroupAndUser(Group group, User user);
 

--- a/src/main/java/com/ting/ting/service/GroupLikeServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupLikeServiceImpl.java
@@ -95,8 +95,13 @@ public class GroupLikeServiceImpl extends AbstractService implements GroupLikeSe
 
         Page<GroupLikeToJoin> groupLikesToJoin = groupLikeToJoinRepository.findAllByFromUser(user, pageable);
         List<Long> likedGroupIds = groupLikesToJoin.stream().map(GroupLikeToJoin::getToGroup).map(Group::getId).collect(Collectors.toUnmodifiableList());
-        List<GroupWithMemberCount> likedGroupsWithMemberCount = groupRepository.findAllWithMemberCountByIdIn(likedGroupIds);
 
+        // 찜한 기록이 없는 경우는 바로 return
+        if (groupLikesToJoin.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, groupLikesToJoin.getTotalElements());
+        }
+
+        List<GroupWithMemberCount> likedGroupsWithMemberCount = groupRepository.findAllWithMemberCountByIdIn(likedGroupIds);
         Set<Long> pendingJoinRequestGroupIds = groupMemberRequestRepository.findAllByUser(user).stream().map(GroupMemberRequest::getGroup).map(Group::getId).collect(Collectors.toUnmodifiableSet());
 
         List<JoinableGroupResponse> likedJoinableGroupResponses = likedGroupsWithMemberCount.stream()

--- a/src/main/java/com/ting/ting/service/GroupMemberService.java
+++ b/src/main/java/com/ting/ting/service/GroupMemberService.java
@@ -1,0 +1,49 @@
+package com.ting.ting.service;
+
+import com.ting.ting.dto.response.GroupMemberRequestResponse;
+import com.ting.ting.dto.response.GroupMemberResponse;
+
+import java.util.Set;
+
+public interface GroupMemberService {
+
+    /**
+     * 같은 성별인 팀에 요청
+     */
+    void saveJoinRequest(long groupId, long userId);
+
+    /**
+     * 같은 성별인 팀에 했던 요청을 취소
+     */
+    void deleteJoinRequest(long groupId, long userId);
+
+    /**
+     * 팀 멤버에서 삭제(팀 나가기)
+     */
+    void deleteGroupMember(long groupId, long userId);
+
+    /**
+     * 팀장 - 팀장 넘기기
+     */
+    Set<GroupMemberResponse> changeGroupLeader(long groupId, long userIdOfLeader, long userIdOfNewLeader);
+
+    /**
+     * 팀 멤버 조회
+     */
+    Set<GroupMemberResponse> findGroupMemberList(Long groupId);
+
+    /**
+     * 팀장 - 팀에 온 멤버 가입 요청을 조회
+     */
+    Set<GroupMemberRequestResponse> findMemberJoinRequest(long groupId, long userIdOfLeader);
+
+    /**
+     * 팀장 - 팀에 온 멤버 가입 요청을 수락
+     */
+    GroupMemberResponse acceptMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId);
+
+    /**
+     * 팀장 - 팀에 온 멤버 가입 요청을 거절
+     */
+    void rejectMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId);
+}

--- a/src/main/java/com/ting/ting/service/GroupMemberService.java
+++ b/src/main/java/com/ting/ting/service/GroupMemberService.java
@@ -2,6 +2,9 @@ package com.ting.ting.service;
 
 import com.ting.ting.dto.response.GroupMemberRequestResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
+import com.ting.ting.dto.response.JoinableGroupResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Set;
 
@@ -26,6 +29,11 @@ public interface GroupMemberService {
      * 팀장 - 팀장 넘기기
      */
     Set<GroupMemberResponse> changeGroupLeader(long groupId, long userIdOfLeader, long userIdOfNewLeader);
+
+    /**
+     * 유저가 과팅 팀에 했던 가입 요청 조회
+     */
+    Page<JoinableGroupResponse> findUserJoinRequestList(Long userId, Pageable pageable);
 
     /**
      * 팀 멤버 조회

--- a/src/main/java/com/ting/ting/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupMemberServiceImpl.java
@@ -1,0 +1,202 @@
+package com.ting.ting.service;
+
+import com.ting.ting.domain.Group;
+import com.ting.ting.domain.GroupMember;
+import com.ting.ting.domain.GroupMemberRequest;
+import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.MemberRole;
+import com.ting.ting.dto.response.GroupMemberRequestResponse;
+import com.ting.ting.dto.response.GroupMemberResponse;
+import com.ting.ting.exception.ErrorCode;
+import com.ting.ting.exception.ServiceType;
+import com.ting.ting.repository.GroupMemberRepository;
+import com.ting.ting.repository.GroupMemberRequestRepository;
+import com.ting.ting.repository.GroupRepository;
+import com.ting.ting.repository.UserRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Transactional
+@Component
+public class GroupMemberServiceImpl extends AbstractService implements GroupMemberService {
+
+    private final UserRepository userRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupMemberRequestRepository groupMemberRequestRepository;
+
+    public GroupMemberServiceImpl(UserRepository userRepository, GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, GroupMemberRequestRepository groupMemberRequestRepository) {
+        super(ServiceType.GROUP_MEETING);
+        this.userRepository = userRepository;
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.groupMemberRequestRepository = groupMemberRequestRepository;
+    }
+
+    @Override
+    public void saveJoinRequest(long groupId, long userId) {
+        Group group = loadGroupByGroupId(groupId);
+        User user = loadUserByUserId(userId);
+
+        if (group.getGender() != user.getGender()) {
+            throwException(ErrorCode.GENDER_NOT_MATCH, String.format("Gender values of Group(id:%d) and User(id:%d) do not match", groupId, userId));
+        }
+
+        if (group.isJoinable() == false) {
+            throwException(ErrorCode.REACHED_MEMBERS_SIZE_LIMIT, String.format("Maximum Group(id: %d) capacity of %d members reached", groupId, group.getMemberSizeLimit()));
+        }
+
+        groupMemberRequestRepository.findByGroupAndUser(group, user).ifPresent(it -> {
+            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id:%d) already requested to join the Group(id:%d)", userId, groupId));
+        });
+
+        if (groupMemberRepository.existsByGroupAndMember(group, user)) {
+            throwException(ErrorCode.ALREADY_JOINED, String.format("User(id: %d) already joined to Group(id: %d)", userId, groupId));
+        }
+
+        groupMemberRequestRepository.save(GroupMemberRequest.of(group, user));
+    }
+
+    @Override
+    public void deleteJoinRequest(long groupId, long userId) {
+        groupMemberRequestRepository.deleteByGroup_IdAndUser_Id(groupId, userId);
+    }
+
+    @Override
+    public void deleteGroupMember(long groupId, long userId) {
+        Group group = loadGroupByGroupId(groupId);
+        User member = loadUserByUserId(userId);
+
+        GroupMember memberRecordOfUser = groupMemberRepository.findByGroupAndMember(group, member).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("User(id: %d) is not a member of the Group(id: %d)", userId, group))
+        );
+
+        // 팀에서 나가려는 유저가 그 팀의 리더라면
+        if (memberRecordOfUser.getRole().equals(MemberRole.LEADER)) {
+            GroupMember memberRecordOfNewLeader = loadAvailableMemberAsNewLeaderInGroup(group);
+            groupMemberRepository.delete(memberRecordOfUser);
+            memberRecordOfNewLeader.setRole(MemberRole.LEADER);
+            return;
+        }
+
+        groupMemberRepository.delete(memberRecordOfUser);
+    }
+
+    @Override
+    public Set<GroupMemberResponse> changeGroupLeader(long groupId, long userIdOfLeader, long userIdOfNewLeader) {
+        if (userIdOfLeader == userIdOfNewLeader) {
+            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id: %d) is unable to transfer ownership to themselves.", userIdOfLeader));
+        }
+
+        Group group = loadGroupByGroupId(groupId);
+        User leader = loadUserByUserId(userIdOfLeader);
+        User newLeader = loadUserByUserId(userIdOfNewLeader);
+
+        if (groupMemberRepository.existsByMemberAndRole(newLeader, MemberRole.LEADER)) {
+            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id: %d) is already a leader in another group", newLeader.getId()));
+        }
+
+        GroupMember memberRecordOfLeader = groupMemberRepository.findByGroupAndMemberAndRole(group, leader, MemberRole.LEADER).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("User(id: %d) is not the leader of Group(id: %d)", userIdOfLeader, groupId))
+        );
+        GroupMember memberRecordOfNewLeader = groupMemberRepository.findByGroupAndMemberAndRole(group, newLeader, MemberRole.MEMBER).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("User(id: %d) is not a member of Group(id: %d)", userIdOfNewLeader, groupId))
+        );
+
+        memberRecordOfLeader.setRole(MemberRole.MEMBER);
+        memberRecordOfNewLeader.setRole(MemberRole.LEADER);
+
+        return groupMemberRepository.saveAllAndFlush(List.of(memberRecordOfLeader, memberRecordOfNewLeader)).stream().map(GroupMemberResponse::from).collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public Set<GroupMemberResponse> findGroupMemberList(Long groupId) {
+        Group group = loadGroupByGroupId(groupId);
+
+        return groupMemberRepository.findAllByGroup(group).stream().map(GroupMemberResponse::from).collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public Set<GroupMemberRequestResponse> findMemberJoinRequest(long groupId, long userIdOfLeader) {
+        Group group = loadGroupByGroupId(groupId);
+        User leader = loadUserByUserId(userIdOfLeader);
+
+        throwIfUserIsNotTheLeaderOfGroup(leader, group);
+
+        return groupMemberRequestRepository.findByGroup(group).stream().map(GroupMemberRequestResponse::from).collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public GroupMemberResponse acceptMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId) {
+        User leader = loadUserByUserId(userIdOfLeader);
+        GroupMemberRequest groupMemberRequest = groupMemberRequestRepository.findById(groupMemberRequestId).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("GroupMemberRequest(id: %d) not found", groupMemberRequestId))
+        );
+
+        if (groupMemberRepository.existsByGroupAndMember(groupMemberRequest.getGroup(), groupMemberRequest.getUser())) {
+            groupMemberRequestRepository.delete(groupMemberRequest);
+            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id: %d) is already a member of Group(id: %d)", groupMemberRequest.getUser().getId(), groupMemberRequest.getGroup().getId()));
+        }
+
+        Long actualNumOfMembers = groupMemberRepository.countByGroup(groupMemberRequest.getGroup());
+
+        if (actualNumOfMembers >= groupMemberRequest.getGroup().getMemberSizeLimit()) {
+            throwException(ErrorCode.REACHED_MEMBERS_SIZE_LIMIT, String.format("Maximum Group(id: %d) capacity of %d members reached", groupMemberRequest.getGroup().getId(), groupMemberRequest.getGroup().getMemberSizeLimit()));
+        }
+
+        throwIfUserIsNotTheLeaderOfGroup(leader, groupMemberRequest.getGroup());
+
+        GroupMember created = groupMemberRepository.save(GroupMember.of(groupMemberRequest.getGroup(), groupMemberRequest.getUser(), MemberRole.MEMBER));
+        groupMemberRequestRepository.delete(groupMemberRequest);
+
+        if (actualNumOfMembers + 1 >= groupMemberRequest.getGroup().getMemberSizeLimit()) {
+            groupMemberRequest.getGroup().setJoinable(false);
+        }
+
+        return GroupMemberResponse.from(created);
+    }
+
+    @Override
+    public void rejectMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId) {
+        User leader = loadUserByUserId(userIdOfLeader);
+        GroupMemberRequest groupMemberRequest = groupMemberRequestRepository.findById(groupMemberRequestId).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("GroupMemberRequest(id: %d) not found", groupMemberRequestId))
+        );
+
+        throwIfUserIsNotTheLeaderOfGroup(leader, groupMemberRequest.getGroup());
+
+        groupMemberRequestRepository.delete(groupMemberRequest);
+    }
+
+    private void throwIfUserIsNotTheLeaderOfGroup(User leader, Group group) {
+        if (!groupMemberRepository.existsByGroupAndMemberAndRole(group, leader, MemberRole.LEADER)) {
+            throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) is not the leader of Group(id: %d)", leader.getId(), group.getId()));
+        }
+    }
+
+    private GroupMember loadAvailableMemberAsNewLeaderInGroup(Group group) {
+        List<GroupMember> members = groupMemberRepository.findAvailableMemberAsALeaderInGroup(group, PageRequest.of(0, 1));
+        if (members.isEmpty()) {
+            throwException(ErrorCode.NO_AVAILABLE_MEMBER_AS_LEADER);
+        }
+
+        return members.get(0);
+    }
+
+    private Group loadGroupByGroupId(Long groupId) {
+        return groupRepository.findById(groupId).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("Group(id: %d) not found", groupId))
+        );
+    }
+
+    private User loadUserByUserId(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() ->
+                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("User(id: %d) not found", userId))
+        );
+    }
+}

--- a/src/main/java/com/ting/ting/service/GroupMemberServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupMemberServiceImpl.java
@@ -1,22 +1,25 @@
 package com.ting.ting.service;
 
-import com.ting.ting.domain.Group;
-import com.ting.ting.domain.GroupMember;
-import com.ting.ting.domain.GroupMemberRequest;
-import com.ting.ting.domain.User;
+import com.ting.ting.domain.*;
+import com.ting.ting.domain.constant.LikeStatus;
 import com.ting.ting.domain.constant.MemberRole;
+import com.ting.ting.domain.constant.RequestStatus;
+import com.ting.ting.domain.custom.GroupWithMemberCount;
 import com.ting.ting.dto.response.GroupMemberRequestResponse;
 import com.ting.ting.dto.response.GroupMemberResponse;
+import com.ting.ting.dto.response.JoinableGroupResponse;
 import com.ting.ting.exception.ErrorCode;
 import com.ting.ting.exception.ServiceType;
-import com.ting.ting.repository.GroupMemberRepository;
-import com.ting.ting.repository.GroupMemberRequestRepository;
-import com.ting.ting.repository.GroupRepository;
-import com.ting.ting.repository.UserRepository;
+import com.ting.ting.repository.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,13 +30,15 @@ public class GroupMemberServiceImpl extends AbstractService implements GroupMemb
 
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
+    private final GroupLikeToJoinRepository groupLikeToJoinRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupMemberRequestRepository groupMemberRequestRepository;
 
-    public GroupMemberServiceImpl(UserRepository userRepository, GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, GroupMemberRequestRepository groupMemberRequestRepository) {
+    public GroupMemberServiceImpl(UserRepository userRepository, GroupRepository groupRepository, GroupLikeToJoinRepository groupLikeToJoinRepository, GroupMemberRepository groupMemberRepository, GroupMemberRequestRepository groupMemberRequestRepository) {
         super(ServiceType.GROUP_MEETING);
         this.userRepository = userRepository;
         this.groupRepository = groupRepository;
+        this.groupLikeToJoinRepository = groupLikeToJoinRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.groupMemberRequestRepository = groupMemberRequestRepository;
     }
@@ -112,6 +117,28 @@ public class GroupMemberServiceImpl extends AbstractService implements GroupMemb
         memberRecordOfNewLeader.setRole(MemberRole.LEADER);
 
         return groupMemberRepository.saveAllAndFlush(List.of(memberRecordOfLeader, memberRecordOfNewLeader)).stream().map(GroupMemberResponse::from).collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public Page<JoinableGroupResponse> findUserJoinRequestList(Long userId, Pageable pageable) {
+        User user = loadUserByUserId(userId);
+
+        Page<GroupMemberRequest> userRequestsToJoin = groupMemberRequestRepository.findAllByUser(user, pageable);
+        List<Long> requestedGroupIds = userRequestsToJoin.stream().map(GroupMemberRequest::getGroup).map(Group::getId).collect(Collectors.toUnmodifiableList());
+
+        // 요청한 기록이 없는 경우는 바로 return
+        if (userRequestsToJoin.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, userRequestsToJoin.getTotalElements());
+        }
+
+        Set<Long> likedGroupIds = groupLikeToJoinRepository.findAllByFromUser(user).stream().map(GroupLikeToJoin::getToGroup).map(Group::getId).collect(Collectors.toUnmodifiableSet());
+        List<GroupWithMemberCount> myRequestedGroupsWithMemberCount = groupRepository.findAllWithMemberCountByIdIn(requestedGroupIds);
+
+        List<JoinableGroupResponse> pendingJoinGroupResponses = myRequestedGroupsWithMemberCount.stream()
+                .map(pendingJoinGroup -> JoinableGroupResponse.from(pendingJoinGroup, RequestStatus.PENDING, likedGroupIds.contains(pendingJoinGroup.getId()) ? LikeStatus.LIKED : LikeStatus.NOT_LIKED))
+                .collect(Collectors.toUnmodifiableList());
+
+        return new PageImpl<>(pendingJoinGroupResponses, pageable, userRequestsToJoin.getTotalElements());
     }
 
     @Override

--- a/src/main/java/com/ting/ting/service/GroupService.java
+++ b/src/main/java/com/ting/ting/service/GroupService.java
@@ -30,49 +30,9 @@ public interface GroupService {
     Set<MyGroupResponse> findMyGroupList(Long userId);
 
     /**
-     * 팀 멤버 조회
-     */
-    Set<GroupMemberResponse> findGroupMemberList(Long groupId);
-
-    /**
      * 그룹 생성
      */
     GroupResponse saveGroup(Long userId, GroupRequest request);
-
-    /**
-     * 같은 성별인 팀에 요청
-     */
-    void saveJoinRequest(long groupId, long userId);
-
-    /**
-     * 같은 성별인 팀에 했던 요청을 취소
-     */
-    void deleteJoinRequest(long groupId, long userId);
-
-    /**
-     * 팀 멤버에서 삭제
-     */
-    void deleteGroupMember(long groupId, long userId);
-
-    /**
-     * 팀장 - 팀장 넘기기
-     */
-    Set<GroupMemberResponse> changeGroupLeader(long groupId, long userIdOfLeader, long userIdOfNewLeader);
-
-    /**
-     * 팀장 - 팀에 온 멤버 가입 요청을 조회
-     */
-    Set<GroupMemberRequestResponse> findMemberJoinRequest(long groupId, long userIdOfLeader);
-
-    /**
-     * 팀장 - 팀에 온 멤버 가입 요청을 수락
-     */
-    GroupMemberResponse acceptMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId);
-
-    /**
-     * 팀장 - 팀에 온 멤버 가입 요청을 거절
-     */
-    void rejectMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId);
 
     /**
      * 팀장 - 팀이 한 과팅 요청과, 받은 과팅 요청 모두 조회

--- a/src/main/java/com/ting/ting/service/GroupServiceImpl.java
+++ b/src/main/java/com/ting/ting/service/GroupServiceImpl.java
@@ -13,7 +13,6 @@ import com.ting.ting.exception.ServiceType;
 import com.ting.ting.repository.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 
 @Transactional
 @Component
@@ -112,13 +110,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public Set<GroupMemberResponse> findGroupMemberList(Long groupId) {
-        Group group = loadGroupByGroupId(groupId);
-
-        return groupMemberRepository.findAllByGroup(group).stream().map(GroupMemberResponse::from).collect(Collectors.toUnmodifiableSet());
-    }
-
-    @Override
     public GroupResponse saveGroup(Long userId, GroupRequest request) {
         User leader = loadUserByUserId(userId);
 
@@ -130,134 +121,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         groupMemberRepository.save(GroupMember.of(group, leader, MemberRole.LEADER));
 
         return GroupResponse.from(group);
-    }
-
-    @Override
-    public void saveJoinRequest(long groupId, long userId) {
-        Group group = loadGroupByGroupId(groupId);
-        User user = loadUserByUserId(userId);
-
-        if (group.getGender() != user.getGender()) {
-            throwException(ErrorCode.GENDER_NOT_MATCH, String.format("Gender values of Group(id:%d) and User(id:%d) do not match", groupId, userId));
-        }
-
-        if (group.isJoinable() == false) {
-            throwException(ErrorCode.REACHED_MEMBERS_SIZE_LIMIT, String.format("Maximum Group(id: %d) capacity of %d members reached", groupId, group.getMemberSizeLimit()));
-        }
-
-        groupMemberRequestRepository.findByGroupAndUser(group, user).ifPresent(it -> {
-            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id:%d) already requested to join the Group(id:%d)", userId, groupId));
-        });
-
-        if (groupMemberRepository.existsByGroupAndMember(group, user)) {
-            throwException(ErrorCode.ALREADY_JOINED, String.format("User(id: %d) already joined to Group(id: %d)", userId, groupId));
-        }
-
-        groupMemberRequestRepository.save(GroupMemberRequest.of(group, user));
-    }
-
-    @Override
-    public void deleteJoinRequest(long groupId, long userId) {
-        groupMemberRequestRepository.deleteByGroup_IdAndUser_Id(groupId, userId);
-    }
-
-    @Override
-    public void deleteGroupMember(long groupId, long userId) {
-        Group group = loadGroupByGroupId(groupId);
-        User member = loadUserByUserId(userId);
-
-        GroupMember memberRecordOfUser = groupMemberRepository.findByGroupAndMember(group, member).orElseThrow(() ->
-                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("User(id: %d) is not a member of the Group(id: %d)", userId, group))
-        );
-
-        // 팀에서 나가려는 유저가 그 팀의 리더라면
-        if (memberRecordOfUser.getRole().equals(MemberRole.LEADER)) {
-            GroupMember memberRecordOfNewLeader = loadAvailableMemberAsNewLeaderInGroup(group);
-            groupMemberRepository.delete(memberRecordOfUser);
-            memberRecordOfNewLeader.setRole(MemberRole.LEADER);
-            return;
-        }
-
-        groupMemberRepository.delete(memberRecordOfUser);
-    }
-
-    @Override
-    public Set<GroupMemberResponse> changeGroupLeader(long groupId, long userIdOfLeader, long userIdOfNewLeader) {
-        if (userIdOfLeader == userIdOfNewLeader) {
-            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id: %d) is unable to transfer ownership to themselves.", userIdOfLeader));
-        }
-
-        Group group = loadGroupByGroupId(groupId);
-        User leader = loadUserByUserId(userIdOfLeader);
-        User newLeader = loadUserByUserId(userIdOfNewLeader);
-
-        if (groupMemberRepository.existsByMemberAndRole(newLeader, MemberRole.LEADER)) {
-            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id: %d) is already a leader in another group", newLeader.getId()));
-        }
-
-        GroupMember memberRecordOfLeader = groupMemberRepository.findByGroupAndMemberAndRole(group, leader, MemberRole.LEADER).orElseThrow(() ->
-                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("User(id: %d) is not the leader of Group(id: %d)", userIdOfLeader, groupId))
-        );
-        GroupMember memberRecordOfNewLeader = groupMemberRepository.findByGroupAndMemberAndRole(group, newLeader, MemberRole.MEMBER).orElseThrow(() ->
-                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("User(id: %d) is not a member of Group(id: %d)", userIdOfNewLeader, groupId))
-        );
-
-        memberRecordOfLeader.setRole(MemberRole.MEMBER);
-        memberRecordOfNewLeader.setRole(MemberRole.LEADER);
-
-        return groupMemberRepository.saveAllAndFlush(List.of(memberRecordOfLeader, memberRecordOfNewLeader)).stream().map(GroupMemberResponse::from).collect(Collectors.toUnmodifiableSet());
-    }
-
-    @Override
-    public Set<GroupMemberRequestResponse> findMemberJoinRequest(long groupId, long userIdOfLeader) {
-        Group group = loadGroupByGroupId(groupId);
-        User leader = loadUserByUserId(userIdOfLeader);
-
-        throwIfUserIsNotTheLeaderOfGroup(leader, group);
-
-        return groupMemberRequestRepository.findByGroup(group).stream().map(GroupMemberRequestResponse::from).collect(Collectors.toUnmodifiableSet());
-    }
-
-    @Override
-    public GroupMemberResponse acceptMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId) {
-        User leader = loadUserByUserId(userIdOfLeader);
-        GroupMemberRequest groupMemberRequest = groupMemberRequestRepository.findById(groupMemberRequestId).orElseThrow(() ->
-                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("GroupMemberRequest(id: %d) not found", groupMemberRequestId))
-        );
-
-        if (groupMemberRepository.existsByGroupAndMember(groupMemberRequest.getGroup(), groupMemberRequest.getUser())) {
-            groupMemberRequestRepository.delete(groupMemberRequest);
-            throwException(ErrorCode.DUPLICATED_REQUEST, String.format("User(id: %d) is already a member of Group(id: %d)", groupMemberRequest.getUser().getId(), groupMemberRequest.getGroup().getId()));
-        }
-
-        Long actualNumOfMembers = groupMemberRepository.countByGroup(groupMemberRequest.getGroup());
-
-        if (actualNumOfMembers >= groupMemberRequest.getGroup().getMemberSizeLimit()) {
-            throwException(ErrorCode.REACHED_MEMBERS_SIZE_LIMIT, String.format("Maximum Group(id: %d) capacity of %d members reached", groupMemberRequest.getGroup().getId(), groupMemberRequest.getGroup().getMemberSizeLimit()));
-        }
-
-        throwIfUserIsNotTheLeaderOfGroup(leader, groupMemberRequest.getGroup());
-
-        GroupMember created = groupMemberRepository.save(GroupMember.of(groupMemberRequest.getGroup(), groupMemberRequest.getUser(), MemberRole.MEMBER));
-        groupMemberRequestRepository.delete(groupMemberRequest);
-
-        if (actualNumOfMembers + 1 >= groupMemberRequest.getGroup().getMemberSizeLimit()) {
-            groupMemberRequest.getGroup().setJoinable(false);
-        }
-
-        return GroupMemberResponse.from(created);
-    }
-
-    @Override
-    public void rejectMemberJoinRequest(long userIdOfLeader, long groupMemberRequestId) {
-        User leader = loadUserByUserId(userIdOfLeader);
-        GroupMemberRequest groupMemberRequest = groupMemberRequestRepository.findById(groupMemberRequestId).orElseThrow(() ->
-                throwException(ErrorCode.REQUEST_NOT_FOUND, String.format("GroupMemberRequest(id: %d) not found", groupMemberRequestId))
-        );
-
-        throwIfUserIsNotTheLeaderOfGroup(leader, groupMemberRequest.getGroup());
-
-        groupMemberRequestRepository.delete(groupMemberRequest);
     }
 
     @Override
@@ -368,15 +231,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         if (!groupMemberRepository.existsByGroupAndMemberAndRole(group, leader, MemberRole.LEADER)) {
             throwException(ErrorCode.INVALID_PERMISSION, String.format("User(id: %d) is not the leader of Group(id: %d)", leader.getId(), group.getId()));
         }
-    }
-
-    private GroupMember loadAvailableMemberAsNewLeaderInGroup(Group group) {
-        List<GroupMember> members = groupMemberRepository.findAvailableMemberAsALeaderInGroup(group, PageRequest.of(0, 1));
-        if (members.isEmpty()) {
-            throwException(ErrorCode.NO_AVAILABLE_MEMBER_AS_LEADER);
-        }
-
-        return members.get(0);
     }
 
     private Group loadGroupByGroupId(Long groupId) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -99,6 +99,7 @@ insert into group_member_request (id, group_id, user_id, created_at, updated_at)
 insert into group_member_request (id, group_id, user_id, created_at, updated_at) values (2, 1, 4, now(), now());
 insert into group_member_request (id, group_id, user_id, created_at, updated_at) values (3, 2, 3, now(), now());
 insert into group_member_request (id, group_id, user_id, created_at, updated_at) values (4, 4, 1, now(), now());
+insert into group_member_request (id, group_id, user_id, created_at, updated_at) values (5, 19, 1, now(), now());
 
 insert into group_like_to_date(id, from_group_member_id, to_group_id, created_at, updated_at) values (1, 1, 10, now(), now());
 

--- a/src/test/java/com/ting/ting/service/GroupMemberServiceTest.java
+++ b/src/test/java/com/ting/ting/service/GroupMemberServiceTest.java
@@ -1,0 +1,381 @@
+package com.ting.ting.service;
+
+import com.ting.ting.domain.Group;
+import com.ting.ting.domain.GroupMember;
+import com.ting.ting.domain.GroupMemberRequest;
+import com.ting.ting.domain.User;
+import com.ting.ting.domain.constant.Gender;
+import com.ting.ting.domain.constant.MemberRole;
+import com.ting.ting.dto.response.GroupMemberResponse;
+import com.ting.ting.exception.ErrorCode;
+import com.ting.ting.exception.TingApplicationException;
+import com.ting.ting.fixture.GroupFixture;
+import com.ting.ting.fixture.UserFixture;
+import com.ting.ting.repository.GroupMemberRepository;
+import com.ting.ting.repository.GroupMemberRequestRepository;
+import com.ting.ting.repository.GroupRepository;
+import com.ting.ting.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("[과팅] 팀 멤버 관련 비즈니스 로직 테스트")
+@ExtendWith(MockitoExtension.class)
+public class GroupMemberServiceTest {
+
+    @InjectMocks private GroupMemberServiceImpl groupMemberService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private GroupRepository groupRepository;
+    @Mock private GroupMemberRepository groupMemberRepository;
+    @Mock private GroupMemberRequestRepository groupMemberRequestRepository;
+
+    private User user;
+
+    @BeforeEach
+    private void setUpUser() {
+        user = UserFixture.createUserById(1L);
+    }
+
+    @DisplayName("팀 멤버 조회 기능 테스트")
+    @Test
+    void Given_Group_When_FindGroupMemberList_Then_ReturnsGroupMemberSet() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(groupId);
+        GroupMember member1 = GroupMember.of(group, user, MemberRole.MEMBER);
+        GroupMember member2 = GroupMember.of(group, UserFixture.createUserById(user.getId() + 1), MemberRole.MEMBER);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(groupMemberRepository.findAllByGroup(any())).willReturn(List.of(member1, member2));
+
+        //When & Then
+        assertThat(groupMemberService.findGroupMemberList(group.getId())).hasSize(2);
+    }
+
+    @DisplayName("멤버 가입 요청 기능 테스트")
+    @Test
+    void Given_Group_When_SaveJoinRequest_Then_SavesRequest() {
+        //Given
+        Long groupId = 1L;
+
+        ReflectionTestUtils.setField(user, "gender", Gender.WOMEN);
+        Group group = GroupFixture.createGroupById(groupId);
+        ReflectionTestUtils.setField(group, "gender", Gender.WOMEN);
+        ReflectionTestUtils.setField(group, "isJoinable", true);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(groupMemberRequestRepository.findByGroupAndUser(any(), any())).willReturn(Optional.empty());
+        given(groupMemberRepository.existsByGroupAndMember(any(), any())).willReturn(false);
+        given(groupMemberRequestRepository.save(any())).willReturn(any(GroupMemberRequest.class));
+
+        //When & Then
+        assertDoesNotThrow(() -> groupMemberService.saveJoinRequest(groupId, user.getId()));
+    }
+
+    @DisplayName("멤버 가입 요청 기능 테스트 - 성별이 다른 경우")
+    @Test
+    void Given_GroupAndUserWithDifferentGenderValues_When_SaveJoinRequest_Then_ThrowsException() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(groupId);
+        ReflectionTestUtils.setField(group, "gender", Gender.MEN);
+        ReflectionTestUtils.setField(user, "gender", Gender.WOMEN);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+
+        //When
+        Throwable t = catchThrowable(() -> groupMemberService.saveJoinRequest(groupId, user.getId()));
+
+        //Then
+        Assertions.assertThat(t)
+                .isInstanceOf(TingApplicationException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GENDER_NOT_MATCH);
+        then(groupMemberRequestRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("멤버 가입 요청 기능 테스트 - 이미 팀에 가입 요청을 보낸 멤버일 경우")
+    @Test
+    void Given_GroupAndUserWhoAlreadyRequestedToJoin_When_SaveJoinRequest_Then_ThrowsException() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(groupId);
+        ReflectionTestUtils.setField(group, "isJoinable", true);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(groupMemberRequestRepository.findByGroupAndUser(any(), any())).willReturn(Optional.of(mock(GroupMemberRequest.class)));
+
+        //When
+        Throwable t = catchThrowable(() -> groupMemberService.saveJoinRequest(groupId, user.getId()));
+
+        //Then
+        Assertions.assertThat(t)
+                .isInstanceOf(TingApplicationException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DUPLICATED_REQUEST);
+        then(groupMemberRequestRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("멤버 가입 요청 기능 테스트 - 이미 팀에 소속된 멤버일 경우")
+    @Test
+    void Given_GroupAndUserWhoIsAMemberOfTheGroup_When_SaveJoinRequest_Then_ThrowsException() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(groupId);
+        ReflectionTestUtils.setField(group, "isJoinable", true);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(groupMemberRequestRepository.findByGroupAndUser(any(), any())).willReturn(Optional.empty());
+        given(groupMemberRepository.existsByGroupAndMember(any(), any())).willReturn(true);
+
+        //When
+        Throwable t = catchThrowable(() -> groupMemberService.saveJoinRequest(groupId, user.getId()));
+
+        //Then
+        Assertions.assertThat(t)
+                .isInstanceOf(TingApplicationException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_JOINED);
+        then(groupMemberRequestRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("멤버 가입 요청 취소 기능 테스트")
+    @Test
+    void Given_Group_When_DeleteJoinRequest_Then_DeletesRequest() {
+        //Given
+        Long groupId = 1L;
+
+        willDoNothing().given(groupMemberRequestRepository).deleteByGroup_IdAndUser_Id(any(), any());
+
+        //When & Then
+        assertDoesNotThrow(() -> groupMemberService.deleteJoinRequest(groupId, user.getId()));
+    }
+
+    @DisplayName("팀 나오기 기능 테스트 - 나오려는 유저가 팀의 리더가 아닌 경우")
+    @Test
+    void Given_Group_When_DeleteGroupMember_Then_DeletesMember() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(groupId);
+        GroupMember memberRecordOfMember = GroupMember.of(group, user, MemberRole.MEMBER);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(groupMemberRepository.findByGroupAndMember(any(), any())).willReturn(Optional.of(memberRecordOfMember));
+
+        //When
+        groupMemberService.deleteGroupMember(groupId, user.getId());
+
+        //Then
+        assertDoesNotThrow(() -> groupMemberRepository.delete(memberRecordOfMember));
+    }
+
+    @DisplayName("팀 나오기 기능 테스트 - 나오려는 유저가 팀의 리더인 경우, 팀장 가능한 멤버가 있는 경우")
+    @Test
+    void Given_GroupWithAvailableMemberAsNewLeaderAndLeaderWhen_DeleteGroupMember_Then_DeletesLeaderAndMakesTheMemberAsNewLeader() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(groupId);
+        User newLeader = UserFixture.createUserById(user.getId() + 1);
+        GroupMember memberRecordOfLeader = GroupMember.of(group, user, MemberRole.LEADER);
+        GroupMember memberRecordOfMember = GroupMember.of(group, newLeader, MemberRole.MEMBER);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(groupMemberRepository.findByGroupAndMember(any(), any())).willReturn(Optional.of(memberRecordOfLeader));
+        given(groupMemberRepository.findAvailableMemberAsALeaderInGroup(any(), any())).willReturn(List.of(memberRecordOfMember));
+
+        //When
+        groupMemberService.deleteGroupMember(groupId, user.getId());
+
+        //Then
+        Assertions.assertThat(memberRecordOfMember.getRole()).isSameAs(MemberRole.LEADER);
+        then(groupMemberRepository).should().delete(any());
+        then(groupMemberRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("팀 나오기 기능 테스트 - 나오려는 유저가 팀의 리더인 경우, 팀장 가능한 멤버가 없는 경우")
+    @Test
+    void Given_GroupWithNoAvailableMemberAsNewLeaderAndLeader_When_DeleteGroupMember_Then_ThrowsException() {
+        //Given
+        Long groupId = 1L;
+
+        GroupMember memberRecordOfLeader = GroupMember.of(GroupFixture.createGroupById(groupId), user, MemberRole.LEADER);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(mock(Group.class)));
+        given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
+        given(groupMemberRepository.findByGroupAndMember(any(), any())).willReturn(Optional.of(memberRecordOfLeader));
+        given(groupMemberRepository.findAvailableMemberAsALeaderInGroup(any(), any())).willReturn(List.of());
+
+        //When
+        Throwable t = catchThrowable(() ->  groupMemberService.deleteGroupMember(groupId, user.getId()));
+
+        //Then
+        Assertions.assertThat(t)
+                .isInstanceOf(TingApplicationException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AVAILABLE_MEMBER_AS_LEADER);
+        then(groupMemberRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[팀장] : 팀장 넘기기 기능 테스트")
+    @Test
+    void Given_GroupAndMemberAsNewLeader_When_ChangeGroupLeader_Then_ReturnsGroupMemberResponseOfNewLeader() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(1L);
+        User newLeader = UserFixture.createUserById(user.getId() + 1);
+        GroupMember memberRecordOfLeader = GroupMember.of(group, user, MemberRole.LEADER);
+        GroupMember memberRecordOfMember = GroupMember.of(group, newLeader, MemberRole.MEMBER);
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(group));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(userRepository.findById(any())).willReturn(Optional.of(newLeader));
+        given(groupMemberRepository.existsByMemberAndRole(any(), any())).willReturn(false);
+        given(groupMemberRepository.findByGroupAndMemberAndRole(any(), any(), any())).willReturn(Optional.of(memberRecordOfLeader)).willReturn(Optional.of(memberRecordOfMember));
+
+        //When
+        Set<GroupMemberResponse> actual = groupMemberService.changeGroupLeader(groupId, user.getId(), newLeader.getId());
+
+        //Then
+        Assertions.assertThat(memberRecordOfLeader.getRole()).isSameAs(MemberRole.MEMBER);
+        Assertions.assertThat(memberRecordOfMember.getRole()).isSameAs(MemberRole.LEADER);
+    }
+
+
+    @DisplayName("[팀장] : 멤버 가입 요청 조회 기능 테스트")
+    @Test
+    void Given_Group_When_FindMemberJoinRequest_Then_ReturnsGroupMemberRequestSet() {
+        //Given
+        Long groupId = 1L;
+
+        Group group = GroupFixture.createGroupById(groupId);
+        GroupMemberRequest request1 = GroupMemberRequest.of(group, UserFixture.createUserById(user.getId() + 1));
+        GroupMemberRequest request2 = GroupMemberRequest.of(group, UserFixture.createUserById(user.getId() + 1));
+
+        given(groupRepository.findById(any())).willReturn(Optional.of(mock(Group.class)));
+        given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
+        given(groupMemberRepository.existsByGroupAndMemberAndRole(any(), any(), any())).willReturn(true);
+        given(groupMemberRequestRepository.findByGroup(any())).willReturn(List.of(request1, request2));
+
+        //When & Then
+        assertThat(groupMemberService.findMemberJoinRequest(groupId, user.getId())).hasSize(2);
+    }
+
+    @DisplayName("[팀장] : 멤버 가입 요청 수락 기능 테스트")
+    @Test
+    void Given_GroupMemberRequest_When_AcceptMemberJoinRequest_Then_ReturnsCreatedGroupMemberResponse() {
+        //Given
+        Long groupMemberRequestId = 1L;
+
+        Group group = GroupFixture.createGroupById(1L);
+        group.setMemberSizeLimit(3);
+        GroupMemberRequest request = GroupMemberRequest.of(group, UserFixture.createUserById(user.getId() + 1));
+
+        given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
+        given(groupMemberRequestRepository.findById(any())).willReturn(Optional.of(request));
+        given(groupMemberRepository.existsByGroupAndMember(any(), any())).willReturn(false);
+        given(groupMemberRepository.countByGroup(group)).willReturn(2L);
+        given(groupMemberRepository.existsByGroupAndMemberAndRole(any(), any(), any())).willReturn(true);
+        given(groupMemberRepository.save(any())).willReturn(GroupMember.of(group, request.getUser(), MemberRole.MEMBER));
+
+        //When
+        GroupMemberResponse actual = groupMemberService.acceptMemberJoinRequest(user.getId(), groupMemberRequestId);
+
+        //Then
+        Assertions.assertThat(actual.getMember().getUsername()).isSameAs(request.getUser().getUsername());
+        then(groupMemberRepository).should().save(any(GroupMember.class));
+        then(groupMemberRequestRepository).should().delete(any());
+    }
+
+    @DisplayName("[팀장] : 멤버 가입 요청 수락 기능 테스트 - 요청한 유저가 이미 멤버인 경우")
+    @Test
+    void Given_GroupMemberRequestWhichContainsMember_When_AcceptMemberJoinRequest_Then_ThrowsException() {
+        //Given
+        Long groupMemberRequestId = 1L;
+
+        GroupMemberRequest request = GroupMemberRequest.of(GroupFixture.createGroupById(1L), UserFixture.createUserById(user.getId() + 1));
+
+        given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
+        given(groupMemberRequestRepository.findById(any())).willReturn(Optional.of(request));
+        given(groupMemberRepository.existsByGroupAndMember(any(), any())).willReturn(true);
+
+        //When
+        Throwable t = catchThrowable(() -> groupMemberService.acceptMemberJoinRequest(user.getId(), groupMemberRequestId));
+
+        //Then
+        Assertions.assertThat(t)
+                .isInstanceOf(TingApplicationException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DUPLICATED_REQUEST);
+        then(groupMemberRequestRepository).should().delete(any(GroupMemberRequest.class));
+        then(groupMemberRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[팀장] : 멤버 가입 요청 수락 기능 테스트 - 팀의 가능한 멤버 수가 꽉찬 경우")
+    @Test
+    void Given_GroupMemberRequestWhichContainsFullGroup_When_AcceptMemberJoinRequest_Then_ThrowsException() {
+        //Given
+        Long groupMemberRequestId = 1L;
+
+        Group group = GroupFixture.createGroupById(1L);
+        group.setMemberSizeLimit(3);
+        GroupMemberRequest request = GroupMemberRequest.of(group, UserFixture.createUserById(user.getId() + 1));
+
+        given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
+        given(groupMemberRequestRepository.findById(any())).willReturn(Optional.of(request));
+        given(groupMemberRepository.existsByGroupAndMember(any(), any())).willReturn(false);
+        given(groupMemberRepository.countByGroup(group)).willReturn(3L);
+
+        //When
+        Throwable t = catchThrowable(() -> groupMemberService.acceptMemberJoinRequest(user.getId(), groupMemberRequestId));
+
+        //Then
+        Assertions.assertThat(t)
+                .isInstanceOf(TingApplicationException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REACHED_MEMBERS_SIZE_LIMIT);
+        then(groupMemberRequestRepository).shouldHaveNoMoreInteractions();
+        then(groupMemberRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @DisplayName("[팀장] : 멤버 가입 요청 거절 기능 테스트")
+    @Test
+    void Given_GroupMemberRequest_When_RejectMemberJoinRequest_Then_DeletesMemberJoinRequest() {
+        //Given
+        Long groupMemberRequestId = 1L;
+
+        given(userRepository.findById(any())).willReturn(Optional.of(mock(User.class)));
+        given(groupMemberRequestRepository.findById(any())).willReturn(Optional.of(mock(GroupMemberRequest.class)));
+        given(groupMemberRepository.existsByGroupAndMemberAndRole(any(), any(), any())).willReturn(true);
+
+        //When
+        groupMemberService.rejectMemberJoinRequest(user.getId(), groupMemberRequestId);
+
+        //Then
+        then(groupMemberRequestRepository).should().delete(any(GroupMemberRequest.class));
+    }
+}


### PR DESCRIPTION
찜 기능과 비즈니스 로직이 비슷합니다!

### api가 사용될 페이지

<img src="https://github.com/realSolarDragons/back-end/assets/83967710/564c19b9-4a04-4e27-8c3a-739f401e3264" width="50%" height="70%"/>

### api 결과
<img src="https://github.com/realSolarDragons/back-end/assets/83967710/bf8f5152-99b4-41a8-8ae8-919ea95f81eb" width="50%" height="70%"/>


This closes #118 