### PR TITLE
[유저] 토큰 생성 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ting/ting/configuration/SecurityConfig.java
+++ b/src/main/java/com/ting/ting/configuration/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.ting.ting.configuration;
+
+import com.ting.ting.util.JwtTokenGenerator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityConfig {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Bean
+    public JwtTokenGenerator JwtTokenGenerator() {
+        return new JwtTokenGenerator(secret);
+    }
+}

--- a/src/main/java/com/ting/ting/controller/UserController.java
+++ b/src/main/java/com/ting/ting/controller/UserController.java
@@ -24,4 +24,9 @@ public class UserController extends AbstractController {
     public Response<LogInResponse> logIn(@RequestParam String code) {
         return success(userService.logIn(code));
     }
+
+    @GetMapping("/test")
+    public Long test(@RequestParam String token) {
+        return userService.test(token);
+    }
 }

--- a/src/main/java/com/ting/ting/dto/response/LogInResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/LogInResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class LogInResponse {
 
     private boolean isRegistered;
-    private boolean token;
+    private String token;
 
     public LogInResponse(boolean isRegistered) {
         this.isRegistered = isRegistered;

--- a/src/main/java/com/ting/ting/exception/ErrorCode.java
+++ b/src/main/java/com/ting/ting/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     REQUEST_NOT_MINE(HttpStatus.BAD_REQUEST,"This is not the request information that came to me"),
     NOT_MY_REQUEST(HttpStatus.BAD_REQUEST,"This is not a request I sent."),
     QR_GENERATOR_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An error occurred in the QR generator"),
+    TOKEN_ERROR(HttpStatus.BAD_REQUEST, "Token generation error"),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error")
     ;

--- a/src/main/java/com/ting/ting/exception/ServiceType.java
+++ b/src/main/java/com/ting/ting/exception/ServiceType.java
@@ -4,6 +4,7 @@ public enum ServiceType {
     USER,
     ADMIN,
     KAKAO,
+    UTIL,
     BLIND,
     GROUP_MEETING
 }

--- a/src/main/java/com/ting/ting/service/UserService.java
+++ b/src/main/java/com/ting/ting/service/UserService.java
@@ -31,6 +31,10 @@ public class UserService extends AbstractService{
                 .orElse(new LogInResponse(false));
     }
 
+    public Long test(String token) {
+        return jwtTokenGenerator.getIdByToken(token);
+    }
+
     private String createToken(String socialEmail) {
         User user = getUserBySocialEmail(socialEmail);
         return jwtTokenGenerator.createTokenById(user.getId());

--- a/src/main/java/com/ting/ting/service/UserService.java
+++ b/src/main/java/com/ting/ting/service/UserService.java
@@ -1,31 +1,48 @@
 package com.ting.ting.service;
 
+import com.ting.ting.domain.User;
 import com.ting.ting.dto.response.LogInResponse;
+import com.ting.ting.exception.ErrorCode;
+import com.ting.ting.exception.ServiceType;
 import com.ting.ting.repository.UserRepository;
+import com.ting.ting.util.JwtTokenGenerator;
 import com.ting.ting.util.KakaoInfoGenerator;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UserService {
+public class UserService extends AbstractService{
 
     private final UserRepository userRepository;
     private final KakaoInfoGenerator kakaoInfoGenerator;
+    private final JwtTokenGenerator jwtTokenGenerator;
 
-    public UserService(UserRepository userRepository, KakaoInfoGenerator kakaoInfoGenerator) {
+    public UserService(UserRepository userRepository, KakaoInfoGenerator kakaoInfoGenerator, JwtTokenGenerator jwtTokenGenerator) {
+        super(ServiceType.USER);
         this.userRepository = userRepository;
         this.kakaoInfoGenerator = kakaoInfoGenerator;
+        this.jwtTokenGenerator = jwtTokenGenerator;
     }
 
     public LogInResponse logIn(String code) {
         String socialEmail = getSocialEmailByCode(code);
 
         return userRepository.findBySocialEmail(socialEmail)
-                .map(response -> new LogInResponse(true))
+                .map(response -> new LogInResponse(true, createToken(socialEmail)))
                 .orElse(new LogInResponse(false));
     }
 
-    public String getSocialEmailByCode(String code) {
+    private String createToken(String socialEmail) {
+        User user = getUserBySocialEmail(socialEmail);
+        return jwtTokenGenerator.createTokenById(user.getId());
+    }
+
+    private String getSocialEmailByCode(String code) {
         String accessToken = kakaoInfoGenerator.getKakaoTokenResponse(code).getAccess_token();
         return kakaoInfoGenerator.getKakaoUserInfoResponse(accessToken).getKakao_account().getEmail();
+    }
+
+    private User getUserBySocialEmail(String socialEmail) {
+        return userRepository.findBySocialEmail(socialEmail).orElseThrow(() ->
+                throwException(ErrorCode.USER_NOT_FOUND, String.format("[%s]의 유저 정보가 존재하지 않습니다.", socialEmail)));
     }
 }

--- a/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
+++ b/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
@@ -1,7 +1,9 @@
 package com.ting.ting.util;
 
-import io.jsonwebtoken.Header;
-import io.jsonwebtoken.Jwts;
+import com.ting.ting.exception.ErrorCode;
+import com.ting.ting.exception.ServiceType;
+import com.ting.ting.exception.TingApplicationException;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 
 import java.nio.charset.StandardCharsets;
@@ -31,6 +33,21 @@ public class JwtTokenGenerator {
                 .setSubject("user-auto")
                 .signWith(key)
                 .compact();
+    }
+
+    public boolean validToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(this.key).build().parseClaimsJws(token).getBody();
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            throw new TingApplicationException(ErrorCode.TOKEN_ERROR, ServiceType.UTIL, "Invalid JWT signature.");
+        } catch (ExpiredJwtException e) {
+            throw new TingApplicationException(ErrorCode.TOKEN_ERROR, ServiceType.UTIL, "Expired JWT token.");
+        } catch (UnsupportedJwtException e) {
+            throw new TingApplicationException(ErrorCode.TOKEN_ERROR, ServiceType.UTIL, "Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            throw new TingApplicationException(ErrorCode.TOKEN_ERROR, ServiceType.UTIL, "Invalid JWT token");
+        }
     }
 }
 

--- a/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
+++ b/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
@@ -1,0 +1,36 @@
+package com.ting.ting.util;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JwtTokenGenerator {
+
+    private final Key key;
+
+    public JwtTokenGenerator(String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createTokenById(Long id) {
+        Map<String, Object> payloads = new HashMap<>();
+        payloads.put("id", id);
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + Duration.ofDays(1).toMillis());
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(payloads)
+                .setExpiration(expiration)
+                .setSubject("user-auto")
+                .signWith(key)
+                .compact();
+    }
+}
+

--- a/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
+++ b/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
@@ -49,5 +49,14 @@ public class JwtTokenGenerator {
             throw new TingApplicationException(ErrorCode.TOKEN_ERROR, ServiceType.UTIL, "Invalid JWT token");
         }
     }
+
+    public Long getIdByToken(String token) {
+        Claims body = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return body.get("id", Long.class);
+    }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,6 @@ kakao:
   user-info-url: ${USER_INFO_URL}
   logout-url: ${LOGOUT_URL}
   user-name-attribute: id
+
+jwt:
+  secret: ${JWT_SECRET}


### PR DESCRIPTION
유저 토큰 생성 로직을 구현하였습니다.

기본적으로 현재는 kakao 로그인을 진행하였을때 유저 정보가 있으면

> isRegistered = true, token = 생성된 토큰

을 반환하게 구현하였습니다.

유저 정보가 없으면

> isRegistered = false, token = null

을 반환하게 구현하였습니다.

해당 과정을 보여드리자면(임의로 등록된 유저의 id가 22라고 가정하였을때)

카카오에서 발급한 인가코드를 서버에 보낸 후 해당 유저가 이미 등록되어있다면,

<img width="1328" alt="스크린샷 2023-06-03 오전 4 19 16" src="https://github.com/realSolarDragons/back-end/assets/50222603/8a8f47f1-047c-44f2-a8c5-86195d974fd3">

이렇게 보이는 것을 확인할 수 있습니다.

해당 토큰의 만료기간은 1일로 설정하였습니다. 후에 좀 더 낮출 계획입니다.(임시 데모용)

이를 발급된 토큰으로 테스트 해보면,

<img width="1305" alt="스크린샷 2023-06-03 오전 4 21 15" src="https://github.com/realSolarDragons/back-end/assets/50222603/1d4c707a-a7f9-44c3-abbe-5b6fedead31a">

제대로 임의로 설정한 id값이 22가 나오는 것을 확인할 수 있습니다.







