### PR TITLE
[유저] 회원가입 구현

### DIFF
--- a/src/main/java/com/ting/ting/controller/UserController.java
+++ b/src/main/java/com/ting/ting/controller/UserController.java
@@ -1,13 +1,12 @@
 package com.ting.ting.controller;
 
+import com.ting.ting.dto.request.SignUpRequest;
 import com.ting.ting.dto.response.LogInResponse;
 import com.ting.ting.dto.response.Response;
+import com.ting.ting.dto.response.SignUpResponse;
 import com.ting.ting.exception.ServiceType;
 import com.ting.ting.service.UserService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/ting")
 @RestController
@@ -25,8 +24,8 @@ public class UserController extends AbstractController {
         return success(userService.logIn(code));
     }
 
-    @GetMapping("/test")
-    public Long test(@RequestParam String token) {
-        return userService.test(token);
+    @PostMapping("/signUp")
+    public Response<SignUpResponse> signUp(@RequestBody SignUpRequest request) {
+        return success(userService.signUp(request));
     }
 }

--- a/src/main/java/com/ting/ting/domain/User.java
+++ b/src/main/java/com/ting/ting/domain/User.java
@@ -2,6 +2,7 @@ package com.ting.ting.domain;
 
 import com.ting.ting.domain.constant.Gender;
 import com.ting.ting.domain.constant.MBTI;
+import com.ting.ting.dto.request.SignUpRequest;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
@@ -28,23 +29,28 @@ public class User extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull @Size(min = 4, max = 100)
+    @NotNull
+    @Size(min = 4, max = 100)
     @Column(unique = true, nullable = false, length = 100)
     private String username;
 
-    @Email @NotNull
-    @Column(name = "social_email",unique = true, nullable = false, length = 100)
+    @Email
+    @NotNull
+    @Column(name = "social_email", unique = true, nullable = false, length = 100)
     private String socialEmail;
 
-    @Email @NotNull
+    @Email
+    @NotNull
     @Column(unique = true, nullable = false, length = 100)
     private String email;
 
-    @NotNull @Size(max = 70)
+    @NotNull
+    @Size(max = 70)
     @Column(length = 70, nullable = false)
     private String school;
 
-    @NotNull @Size(max = 50)
+    @NotNull
+    @Size(max = 50)
     @Column(length = 50, nullable = false)
     private String major;
 
@@ -65,13 +71,14 @@ public class User extends AuditingFields {
 
     private Float height;
 
-    @Column(name="ideal_photo")
+    @Column(name = "ideal_photo")
     private String idealPhoto;
 
     @Column(name = "deleted_at")  // soft-delete
     private LocalDateTime deletedAt;
 
-    protected User() {}
+    protected User() {
+    }
 
     private User(Long id, String username, String socialEmail, String email, String school, String major, Gender gender, LocalDate birth, MBTI mbti, Float weight, Float height, String idealPhoto) {
         this.id = id;
@@ -88,8 +95,30 @@ public class User extends AuditingFields {
         this.idealPhoto = idealPhoto;
     }
 
+    public User(String username, String socialEmail, String email, String school, String major, Gender gender, LocalDate birth) {
+        this.username = username;
+        this.socialEmail = socialEmail;
+        this.email = email;
+        this.school = school;
+        this.major = major;
+        this.gender = gender;
+        this.birth = birth;
+    }
+
+    public static User from(SignUpRequest request) {
+        return new User(
+                request.getUsername(),
+                request.getSocialEmail(),
+                request.getEmail(),
+                request.getSchool(),
+                request.getMajor(),
+                request.getGender(),
+                request.getBirth()
+        );
+    }
+
     public static User of(String username, String socialEmail, String email, String school, String major, Gender gender, LocalDate birth) {
-        return User.of(null, username, socialEmail ,email, school, major, gender, birth);
+        return User.of(null, username, socialEmail, email, school, major, gender, birth);
     }
 
     public static User of(Long id, String username, String socialEmail, String email, String school, String major, Gender gender, LocalDate birth) {

--- a/src/main/java/com/ting/ting/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ting/ting/dto/request/SignUpRequest.java
@@ -1,0 +1,39 @@
+package com.ting.ting.dto.request;
+
+import com.ting.ting.domain.constant.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequest {
+
+    @NotNull
+    private String username;
+
+    @NotNull
+    @Email
+    private String socialEmail;
+
+    @NotNull
+    @Email
+    private String email;
+
+    @NotNull
+    private Gender gender;
+
+    @NotNull
+    private String school;
+
+    @NotNull
+    private String major;
+
+    @NotNull
+    private LocalDate birth;
+}

--- a/src/main/java/com/ting/ting/dto/response/SignUpResponse.java
+++ b/src/main/java/com/ting/ting/dto/response/SignUpResponse.java
@@ -1,0 +1,13 @@
+package com.ting.ting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SignUpResponse {
+
+    private String username;
+
+    private String token;
+}

--- a/src/main/java/com/ting/ting/exception/ErrorCode.java
+++ b/src/main/java/com/ting/ting/exception/ErrorCode.java
@@ -23,8 +23,9 @@ public enum ErrorCode {
     REQUEST_NOT_MINE(HttpStatus.BAD_REQUEST,"This is not the request information that came to me"),
     NOT_MY_REQUEST(HttpStatus.BAD_REQUEST,"This is not a request I sent."),
     QR_GENERATOR_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An error occurred in the QR generator"),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "Username already exists."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "Email already exists."),
     TOKEN_ERROR(HttpStatus.BAD_REQUEST, "Token generation error"),
-
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error")
     ;
 

--- a/src/main/java/com/ting/ting/repository/UserRepository.java
+++ b/src/main/java/com/ting/ting/repository/UserRepository.java
@@ -19,4 +19,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Page<User> findAllByGenderAndIdNotIn(Gender gender, Set<Long> usersId, Pageable pageable);
 
     Optional<User> findBySocialEmail(String socialEmail);
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
+++ b/src/main/java/com/ting/ting/util/JwtTokenGenerator.java
@@ -59,4 +59,3 @@ public class JwtTokenGenerator {
         return body.get("id", Long.class);
     }
 }
-


### PR DESCRIPTION
유저 회원가입 구현 내용입니다.

<img width="1294" alt="스크린샷 2023-06-03 오후 9 24 46" src="https://github.com/realSolarDragons/back-end/assets/50222603/aa170704-9314-4e63-953a-7b15f8afed47">

username, email, gender, school, major, birth 를 front-end에서 입력합니다.

하지만 social logIn 같은 경우에는 입력을 받지 않습니다. 왜냐하면 처음 회원 여부 확인에서 카카오 로그인을 통해 받기 때문입니다. 따라서 회원 여부의 response에서 소셜 이메일 정보를 프론트에게 추가적으로 보낼 예정입니다.


그래서 해당 response에 소셜 이메일까지 보낼 수 있도록 로직을 수정하였습니다. 따라서 회원이 아닐경우 response로는

<img width="1298" alt="스크린샷 2023-06-03 오후 9 36 01" src="https://github.com/realSolarDragons/back-end/assets/50222603/1d89bba7-869c-4fee-916e-c4b76d0bfc25">


여기서 회원이 아니면 회원 가입 로직으로 바뀌는데 이때 소셜 아이디까지 같이 보낼 예정입니다.

회원가입이 최종적으로 완료되면, 

<img width="1310" alt="스크린샷 2023-06-03 오후 9 40 05" src="https://github.com/realSolarDragons/back-end/assets/50222603/f2b23ccf-028b-4877-b83c-f3698a53e63d">


이런식으로 username하고 회원가입이 제대로 동작하였을 경우 생성하는 토큰을 보내게 됩니다. username은 단지 어떤 유저의 회원가입이 제대로 동작하였는지를 보여주는 용도입니다.

해당 생성된 토큰을 확인해보면,

<img width="1250" alt="스크린샷 2023-06-03 오후 9 40 41" src="https://github.com/realSolarDragons/back-end/assets/50222603/acc2c7d2-bfbc-49b9-af81-29cb17a1fd32">

id값 32가 제대로 payload에 저장돼있는 것을 확인할 수 있습니다.

