### PR TITLE
[유저] 인증절차 exception 처리 리팩토링

### DIFF
--- a/src/main/java/com/ting/ting/controller/GroupController.java
+++ b/src/main/java/com/ting/ting/controller/GroupController.java
@@ -61,7 +61,7 @@ public interface GroupController {
     Response<Set<GroupMemberResponse>> getGroupMemberList(@PathVariable Long groupId);
 
     /**
-     * 과팅 가입 요청 조회
+     * 유저가 같은 성별 팀에 한 가입 요청 조회
      */
     @GetMapping("/requests")
     Response<Page<JoinableGroupResponse>> getUserJoinRequestList(@ParameterObject Pageable pageable);

--- a/src/main/java/com/ting/ting/dto/response/Response.java
+++ b/src/main/java/com/ting/ting/dto/response/Response.java
@@ -36,12 +36,11 @@ public class Response<T> {
     }
 
     public String toStream() {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            return "";
-        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"result\":").append(result.toStream()).append(",");
+        sb.append("\"data\":").append(data != null ? "\"" + data + "\"" : null);
+        sb.append("}");
+        return sb.toString();
     }
 }

--- a/src/main/java/com/ting/ting/dto/response/ResultObject.java
+++ b/src/main/java/com/ting/ting/dto/response/ResultObject.java
@@ -37,4 +37,14 @@ public class ResultObject {
     public static ResultObject success(ServiceType serviceType) {
         return new ResultObject(HttpStatus.OK.value(), serviceType.name(), "success");
     }
+
+    public String toStream() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"resultCode\":").append(resultCode).append(",");
+        sb.append("\"serviceType\":").append("\"").append(serviceType).append("\",");
+        sb.append("\"message\":").append("\"").append(message).append("\"");
+        sb.append("}");
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/ting/ting/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/ting/ting/exception/CustomAuthenticationEntryPoint.java
@@ -1,30 +1,32 @@
 package com.ting.ting.exception;
 
 import com.ting.ting.dto.response.Response;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Slf4j
+@Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        if (response.getWriter() == null) {
+            TingApplicationException e = new TingApplicationException(ErrorCode.UNAUTHORIZED, ServiceType.AUTHENTICATION, authException.getMessage());
+            int status = e.getErrorCode().getHttpStatus();
+            Response<?> body = new Response<>(e);
 
-        TingApplicationException e = (TingApplicationException)request.getAttribute("exception");
-        int status = ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus();
-        Response<?> body = Response.error(ErrorCode.INTERNAL_SERVER_ERROR);
-
-        if (e != null && e.getErrorCode() == ErrorCode.INVALID_ACCESS_TOKEN) {
-            status = ErrorCode.INVALID_ACCESS_TOKEN.getHttpStatus();
-            body = new Response<>(e);
+            log.error(e.getMessageForServer());
+            response.setStatus(status);
+            response.getWriter().write(body.toStream());
         }
 
         response.setContentType("application/json");
-        response.setStatus(status);
-        response.getWriter().write(body.toStream());
     }
 }

--- a/src/main/java/com/ting/ting/exception/ErrorCode.java
+++ b/src/main/java/com/ting/ting/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "Email already exists."),
     TOKEN_ERROR(HttpStatus.BAD_REQUEST, "Token generation error"),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token is invalid"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AuthenticationException occurred"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error")
     ;
 


### PR DESCRIPTION
* 기존 Response 관련 객체의 `toStream()` 이 ObjectMapper 를 사용했을 때 exception 처리를 하기 애매한 부분이 있어서
`toStream()` 를 StringBuilder로 구현했습니다. - `Response`, `ResultObject` 코드 참고 부탁드립니다

* CustomAuthenticationEntryPoint.commence 는 인증 절차에서 오류가 나면 넘어가는 메소드입니다. 만약 jwtTokenFilter 에서 오류가 나서 response가 이미 정해져있으면 그걸 그대로 반환하고, jwtTokenFilter 이외의 곳에서 오류가 난 것이면 UNAUTHORIZED 에러를 반환하도록 수정했습니다.

This closes #151 


